### PR TITLE
Remove usage of AXI_ERROR_RESP_G

### DIFF
--- a/core/rtl/AxiPcieDma.vhd
+++ b/core/rtl/AxiPcieDma.vhd
@@ -2,7 +2,7 @@
 -- File       : AxiPcieDma.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-03-06
--- Last update: 2018-02-07
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: Wrapper for AXIS DMA Engine
 -------------------------------------------------------------------------------
@@ -33,8 +33,7 @@ entity AxiPcieDma is
       DMA_SIZE_G        : positive range 1 to 16 := 1;
       INT_PIPE_STAGES_G : natural range 0 to 1   := 1;
       PIPE_STAGES_G     : natural range 0 to 1   := 1;
-      DESC_ARB_G        : boolean                := true;
-      AXI_ERROR_RESP_G  : slv(1 downto 0)        := AXI_RESP_OK_C);
+      DESC_ARB_G        : boolean                := true);
    port (
       -- Clock and reset
       axiClk           : in  sl;
@@ -176,7 +175,6 @@ begin
          DESC_AWIDTH_G     => 12,       -- 4096 entries
          DESC_ARB_G        => DESC_ARB_G,
          AXIL_BASE_ADDR_G  => x"00000000",
-         AXI_ERROR_RESP_G  => AXI_ERROR_RESP_G,
          AXI_READY_EN_G    => false,
          AXIS_READY_EN_G   => false,
          AXIS_CONFIG_G     => INT_DMA_AXIS_CONFIG_C,

--- a/hardware/AdmPcieKu3/core/AdmPcieKu3Core.vhd
+++ b/hardware/AdmPcieKu3/core/AdmPcieKu3Core.vhd
@@ -2,7 +2,7 @@
 -- File       : AdmPcieKu3Core.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-04-06
--- Last update: 2018-02-07
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: AXI PCIe Core for ADM-PCIE-KU3 board 
 --
@@ -90,8 +90,6 @@ entity AdmPcieKu3Core is
 end AdmPcieKu3Core;
 
 architecture mapping of AdmPcieKu3Core is
-
-   constant AXI_ERROR_RESP_C : slv(1 downto 0) := AXI_RESP_OK_C;  -- Always return OK to a MMAP()
 
    signal dmaReadMaster  : AxiReadMasterType;
    signal dmaReadSlave   : AxiReadSlaveType;
@@ -181,7 +179,6 @@ begin
          XIL_DEVICE_G     => "ULTRASCALE",
          BOOT_PROM_G      => "NOT_SUPPORTED",
          DRIVER_TYPE_ID_G => DRIVER_TYPE_ID_G,
-         AXI_ERROR_RESP_G => AXI_ERROR_RESP_C,
          DMA_SIZE_G       => DMA_SIZE_G)
       port map (
          -- AXI4 Interfaces
@@ -219,8 +216,7 @@ begin
       generic map (
          TPD_G            => TPD_G,
          DMA_SIZE_G       => DMA_SIZE_G,
-         DESC_ARB_G       => false,  -- Round robin to help with timing @ 250 MHz system clock
-         AXI_ERROR_RESP_G => AXI_ERROR_RESP_C)
+         DESC_ARB_G       => false)  -- Round robin to help with timing @ 250 MHz system clock
       port map (
          -- Clock and reset
          axiClk           => sysClock,

--- a/hardware/PgpCardG3/rtl/AxiPciePgpCardG3Core.vhd
+++ b/hardware/PgpCardG3/rtl/AxiPciePgpCardG3Core.vhd
@@ -2,7 +2,7 @@
 -- File       : AxiPciePgpCardG3Core.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-03-06
--- Last update: 2018-02-07
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: AXI PCIe Core for the PgpCardG3 board
 -- https://confluence.slac.stanford.edu/display/AIRTRACK/PC_260_101_03_C03
@@ -80,8 +80,6 @@ entity AxiPciePgpCardG3Core is
 end AxiPciePgpCardG3Core;
 
 architecture mapping of AxiPciePgpCardG3Core is
-
-   constant AXI_ERROR_RESP_C : slv(1 downto 0) := AXI_RESP_OK_C;  -- Always return OK to a MMAP()
 
    signal dmaReadMaster  : AxiReadMasterType;
    signal dmaReadSlave   : AxiReadSlaveType;
@@ -170,7 +168,6 @@ begin
          XIL_DEVICE_G     => "7SERIES",
          BOOT_PROM_G      => "BPI",
          DRIVER_TYPE_ID_G => DRIVER_TYPE_ID_G,
-         AXI_ERROR_RESP_G => AXI_ERROR_RESP_C,
          DMA_SIZE_G       => DMA_SIZE_G)
       port map (
          -- AXI4 Interfaces
@@ -230,8 +227,7 @@ begin
          TPD_G             => TPD_G,
          DMA_SIZE_G        => DMA_SIZE_G,
          INT_PIPE_STAGES_G => INT_PIPE_STAGES_G,
-         PIPE_STAGES_G     => PIPE_STAGES_G,
-         AXI_ERROR_RESP_G  => AXI_ERROR_RESP_C)
+         PIPE_STAGES_G     => PIPE_STAGES_G)
       port map (
          -- Clock and reset
          axiClk           => sysClock,

--- a/hardware/XilinxKcu1500/core/rtl/XilinxKcu1500Core.vhd
+++ b/hardware/XilinxKcu1500/core/rtl/XilinxKcu1500Core.vhd
@@ -2,7 +2,7 @@
 -- File       : XilinxKcu1500Core.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-04-06
--- Last update: 2018-02-07
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: AXI PCIe Core for KCU1500 board 
 --
@@ -108,8 +108,6 @@ entity XilinxKcu1500Core is
 end XilinxKcu1500Core;
 
 architecture mapping of XilinxKcu1500Core is
-
-   constant AXI_ERROR_RESP_C : slv(1 downto 0) := AXI_RESP_OK_C;  -- Always return OK to a MMAP()
 
    signal dmaReadMaster  : AxiReadMasterType;
    signal dmaReadSlave   : AxiReadSlaveType;
@@ -240,7 +238,6 @@ begin
          XIL_DEVICE_G     => "ULTRASCALE",
          BOOT_PROM_G      => "SPI",
          DRIVER_TYPE_ID_G => DRIVER_TYPE_ID_G,
-         AXI_ERROR_RESP_G => AXI_ERROR_RESP_C,
          DMA_SIZE_G       => DMA_SIZE_G)
       port map (
          -- AXI4 Interfaces
@@ -328,8 +325,7 @@ begin
       generic map (
          TPD_G            => TPD_G,
          DMA_SIZE_G       => DMA_SIZE_G,
-         DESC_ARB_G       => false,  -- Round robin to help with timing @ 250 MHz system clock
-         AXI_ERROR_RESP_G => AXI_ERROR_RESP_C)
+         DESC_ARB_G       => false)  -- Round robin to help with timing @ 250 MHz system clock
       port map (
          -- Clock and reset
          axiClk           => sysClock,

--- a/hardware/XilinxKcu1500/pcie/extended/core/XilinxKcu1500PcieExtendedCore.vhd
+++ b/hardware/XilinxKcu1500/pcie/extended/core/XilinxKcu1500PcieExtendedCore.vhd
@@ -2,7 +2,7 @@
 -- File       : XilinxKcu1500PcieExtendedCore.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-04-06
--- Last update: 2017-12-04
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: AXI PCIe Core for KCU1500 board 
 --
@@ -72,8 +72,6 @@ entity XilinxKcu1500PcieExtendedCore is
 end XilinxKcu1500PcieExtendedCore;
 
 architecture mapping of XilinxKcu1500PcieExtendedCore is
-
-   constant AXI_ERROR_RESP_C : slv(1 downto 0) := AXI_RESP_OK_C;  -- Always return OK to a MMAP()
 
    signal dmaReadMaster  : AxiReadMasterType;
    signal dmaReadSlave   : AxiReadSlaveType;
@@ -159,7 +157,6 @@ begin
          BOOT_PROM_G      => "NONE",
          DRIVER_TYPE_ID_G => DRIVER_TYPE_ID_G,
          EN_DEVICE_DNA_G  => false,
-         AXI_ERROR_RESP_G => AXI_ERROR_RESP_C,
          DMA_SIZE_G       => DMA_SIZE_G)
       port map (
          -- AXI4 Interfaces
@@ -195,10 +192,9 @@ begin
    ---------------   
    U_AxiPcieDma : entity work.AxiPcieDma
       generic map (
-         TPD_G            => TPD_G,
-         DMA_SIZE_G       => DMA_SIZE_G,
-         DESC_ARB_G       => false,  -- Round robin to help with timing @ 250 MHz system clock
-         AXI_ERROR_RESP_G => AXI_ERROR_RESP_C)
+         TPD_G      => TPD_G,
+         DMA_SIZE_G => DMA_SIZE_G,
+         DESC_ARB_G => false)           -- Round robin to help with timing @ 250 MHz system clock
       port map (
          -- Clock and reset
          axiClk          => sysClock,

--- a/hardware/XilinxVcu1525/rtl/XilinxVcu1525Core.vhd
+++ b/hardware/XilinxVcu1525/rtl/XilinxVcu1525Core.vhd
@@ -2,7 +2,7 @@
 -- File       : XilinxVcu1525Core.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2018-01-29
--- Last update: 2018-02-07
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: AXI PCIe Core for VCU1525 board 
 --
@@ -101,8 +101,6 @@ entity XilinxVcu1525Core is
 end XilinxVcu1525Core;
 
 architecture mapping of XilinxVcu1525Core is
-
-   constant AXI_ERROR_RESP_C : slv(1 downto 0) := AXI_RESP_OK_C;  -- Always return OK to a MMAP()
 
    signal dmaReadMaster  : AxiReadMasterType;
    signal dmaReadSlave   : AxiReadSlaveType;
@@ -213,7 +211,6 @@ begin
          XIL_DEVICE_G     => "ULTRASCALE",
          BOOT_PROM_G      => "SPI",
          DRIVER_TYPE_ID_G => DRIVER_TYPE_ID_G,
-         AXI_ERROR_RESP_G => AXI_ERROR_RESP_C,
          DMA_SIZE_G       => 8)
       port map (
          -- AXI4 Interfaces
@@ -252,25 +249,25 @@ begin
    U_STARTUPE3 : STARTUPE3
       generic map (
          PROG_USR      => "FALSE",  -- Activate program event security feature. Requires encrypted bitstreams.
-         SIM_CCLK_FREQ => 0.0)  -- Set the Configuration Clock Frequency(ns) for simulation
+         SIM_CCLK_FREQ => 0.0)          -- Set the Configuration Clock Frequency(ns) for simulation
       port map (
-         CFGCLK    => open,  -- 1-bit output: Configuration main clock output
+         CFGCLK    => open,             -- 1-bit output: Configuration main clock output
          CFGMCLK   => open,  -- 1-bit output: Configuration internal oscillator clock output
-         DI        => di,  -- 4-bit output: Allow receiving on the D[3:0] input pins
+         DI        => di,               -- 4-bit output: Allow receiving on the D[3:0] input pins
          EOS       => open,  -- 1-bit output: Active high output signal indicating the End Of Startup.
-         PREQ      => open,  -- 1-bit output: PROGRAM request to fabric output
-         DO        => do,  -- 4-bit input: Allows control of the D[3:0] pin outputs
-         DTS       => "1110",  -- 4-bit input: Allows tristate of the D[3:0] pins
-         FCSBO     => bootCsL(0),  -- 1-bit input: Contols the FCS_B pin for flash access
+         PREQ      => open,             -- 1-bit output: PROGRAM request to fabric output
+         DO        => do,               -- 4-bit input: Allows control of the D[3:0] pin outputs
+         DTS       => "1110",           -- 4-bit input: Allows tristate of the D[3:0] pins
+         FCSBO     => bootCsL(0),       -- 1-bit input: Contols the FCS_B pin for flash access
          FCSBTS    => '0',              -- 1-bit input: Tristate the FCS_B pin
          GSR       => '0',  -- 1-bit input: Global Set/Reset input (GSR cannot be used for the port name)
          GTS       => '0',  -- 1-bit input: Global 3-state input (GTS cannot be used for the port name)
          KEYCLEARB => '0',  -- 1-bit input: Clear AES Decrypter Key input from Battery-Backed RAM (BBRAM)
-         PACK      => '0',  -- 1-bit input: PROGRAM acknowledge input
+         PACK      => '0',              -- 1-bit input: PROGRAM acknowledge input
          USRCCLKO  => bootSck(0),       -- 1-bit input: User CCLK input
-         USRCCLKTS => '0',  -- 1-bit input: User CCLK 3-state enable input
-         USRDONEO  => '1',  -- 1-bit input: User DONE pin output control
-         USRDONETS => '0');  -- 1-bit input: User DONE 3-state enable output
+         USRCCLKTS => '0',              -- 1-bit input: User CCLK 3-state enable input
+         USRDONEO  => '1',              -- 1-bit input: User DONE pin output control
+         USRDONETS => '0');             -- 1-bit input: User DONE 3-state enable output
 
    do          <= "111" & bootMosi(0);
    bootMiso(0) <= di(1);
@@ -280,10 +277,9 @@ begin
    ---------------   
    U_AxiPcieDma : entity work.AxiPcieDma
       generic map (
-         TPD_G            => TPD_G,
-         DMA_SIZE_G       => 8,
-         DESC_ARB_G       => false,  -- Round robin to help with timing @ 250 MHz system clock
-         AXI_ERROR_RESP_G => AXI_ERROR_RESP_C)
+         TPD_G      => TPD_G,
+         DMA_SIZE_G => 8,
+         DESC_ARB_G => false)           -- Round robin to help with timing @ 250 MHz system clock
       port map (
          -- Clock and reset
          axiClk           => sysClock,


### PR DESCRIPTION
Updated for compatibility with SURF v1.7.0 - slaclab/surf#147.
 * Removed all AXI_ERROR_RESP_G generics
 * Removed all AxiLiteEmpty instances