### PR TITLE
Refactor for new memory generics in SURF

### DIFF
--- a/protocol/pip/rtl/AxiPciePipCore.vhd
+++ b/protocol/pip/rtl/AxiPciePipCore.vhd
@@ -181,7 +181,7 @@ begin
       U_PacketizerV2 : entity surf.AxiStreamPacketizer2
          generic map (
             TPD_G                => TPD_G,
-            BRAM_EN_G            => true,
+            MEMORY_TYPE_G        => "block",
             REG_EN_G             => true,
             CRC_MODE_G           => "FULL",
             CRC_POLY_G           => x"04C11DB7",
@@ -207,7 +207,7 @@ begin
             VALID_THOLD_G       => (BURST_BYTES_C/PACKETIZER_AXIS_CONFIG_C.TDATA_BYTES_C),
             VALID_BURST_MODE_G  => true,
             -- FIFO configurations
-            BRAM_EN_G           => true,
+            MEMORY_TYPE_G       => "block",
             GEN_SYNC_FIFO_G     => false,
             FIFO_ADDR_WIDTH_G   => 9,
             INT_WIDTH_SELECT_G  => "CUSTOM",
@@ -316,7 +316,7 @@ begin
             INT_PIPE_STAGES_G   => 1,
             PIPE_STAGES_G       => 1,
             -- FIFO configurations
-            BRAM_EN_G           => true,
+            MEMORY_TYPE_G       => "block",
             GEN_SYNC_FIFO_G     => false,
             FIFO_ADDR_WIDTH_G   => 9,
             -- AXI Stream Port Configurations
@@ -337,7 +337,7 @@ begin
       U_Depacketizer : entity surf.AxiStreamDepacketizer2
          generic map (
             TPD_G                => TPD_G,
-            BRAM_EN_G            => true,
+            MEMORY_TYPE_G        => "block",
             REG_EN_G             => true,
             CRC_MODE_G           => "FULL",
             CRC_POLY_G           => x"04C11DB7",

--- a/shared/rtl/AxiPcieDma.vhd
+++ b/shared/rtl/AxiPcieDma.vhd
@@ -74,7 +74,7 @@ architecture mapping of AxiPcieDma is
       TDATA_BYTES_C => DMA_AXIS_CONFIG_G.TDATA_BYTES_C,
       TDEST_BITS_C  => 8,
       TID_BITS_C    => 0,
-      TKEEP_MODE_C  => TKEEP_COUNT_C,  -- AXI DMA V2 uses TKEEP_COUNT_C to help meet timing
+      TKEEP_MODE_C  => TKEEP_COUNT_C,   -- AXI DMA V2 uses TKEEP_COUNT_C to help meet timing
       TUSER_BITS_C  => 4,
       TUSER_MODE_C  => TUSER_FIRST_LAST_C);
 
@@ -144,7 +144,7 @@ begin
       U_V2Gen : entity surf.AxiStreamDmaV2
          generic map (
             TPD_G              => TPD_G,
-            DESC_AWIDTH_G      => 12,   -- 4096 entries
+            DESC_AWIDTH_G      => 12,    -- 4096 entries
             DESC_ARB_G         => DESC_ARB_G,
             DESC_SYNTH_MODE_G  => DESC_SYNTH_MODE_G,
             DESC_MEMORY_TYPE_G => DESC_MEMORY_TYPE_G,
@@ -207,7 +207,7 @@ begin
                SLAVE_READY_EN_G    => true,
                VALID_THOLD_G       => 1,
                -- FIFO configurations
-               BRAM_EN_G           => true,
+               MEMORY_TYPE_G       => "block",
                GEN_SYNC_FIFO_G     => true,
                FIFO_ADDR_WIDTH_G   => 9,
                -- AXI Stream Port Configurations
@@ -236,7 +236,7 @@ begin
                SLAVE_READY_EN_G    => false,
                VALID_THOLD_G       => 1,
                -- FIFO configurations
-               BRAM_EN_G           => true,
+               MEMORY_TYPE_G       => "block",
                GEN_SYNC_FIFO_G     => true,
                FIFO_ADDR_WIDTH_G   => 9,
                FIFO_FIXED_THRESH_G => true,
@@ -326,7 +326,7 @@ begin
          -- .....
          -- .....         
          -------------------------------------------------------         
-         
+
          U_DMA_LANE : entity surf.RogueTcpStreamWrap
             generic map (
                TPD_G         => TPD_G,


### PR DESCRIPTION
The `BRAM_EN_G` generic is now `MEMORY_TYPE_G`.