### PR TITLE
Allow per destination buffer limits in DMA engine

### DIFF
--- a/hardware/AlphaDataKu3/rtl/AlphaDataKu3Core.vhd
+++ b/hardware/AlphaDataKu3/rtl/AlphaDataKu3Core.vhd
@@ -56,42 +56,44 @@ entity AlphaDataKu3Core is
       BUILD_INFO_G         : BuildInfoType;
       DMA_AXIS_CONFIG_G    : AxiStreamConfigType;
       DRIVER_TYPE_ID_G     : slv(31 downto 0)            := x"00000000";
+      DMA_BURST_BYTES_G    : positive range 256 to 4096  := 256;
       DMA_SIZE_G           : positive range 1 to 8       := 1);
    port (
       ------------------------      
       --  Top Level Interfaces
       ------------------------
       -- DMA Interfaces  (dmaClk domain)
-      dmaClk         : out sl;
-      dmaRst         : out sl;
-      dmaObMasters   : out AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
-      dmaObSlaves    : in  AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
-      dmaIbMasters   : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
-      dmaIbSlaves    : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
+      dmaClk          : out sl;
+      dmaRst          : out sl;
+      dmaBuffGrpPause : out slv(7 downto 0);
+      dmaObMasters    : out AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
+      dmaObSlaves     : in  AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
+      dmaIbMasters    : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
+      dmaIbSlaves     : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
       -- Application AXI-Lite Interfaces [0x00100000:0x00FFFFFF] (appClk domain)
-      appClk         : in  sl;
-      appRst         : in  sl;
-      appReadMaster  : out AxiLiteReadMasterType;
-      appReadSlave   : in  AxiLiteReadSlaveType;
-      appWriteMaster : out AxiLiteWriteMasterType;
-      appWriteSlave  : in  AxiLiteWriteSlaveType;
+      appClk          : in  sl;
+      appRst          : in  sl;
+      appReadMaster   : out AxiLiteReadMasterType;
+      appReadSlave    : in  AxiLiteReadSlaveType;
+      appWriteMaster  : out AxiLiteWriteMasterType;
+      appWriteSlave   : in  AxiLiteWriteSlaveType;
       -------------------
       --  Top Level Ports
       -------------------      
       -- QSFP[0] Ports
-      qsfp0RstL      : out sl;
-      qsfp0LpMode    : out sl;
+      qsfp0RstL       : out sl;
+      qsfp0LpMode     : out sl;
       -- QSFP[1] Ports
-      qsfp1RstL      : out sl;
-      qsfp1LpMode    : out sl;
+      qsfp1RstL       : out sl;
+      qsfp1LpMode     : out sl;
       -- PCIe Ports 
-      pciRstL        : in  sl;
-      pciRefClkP     : in  sl;
-      pciRefClkN     : in  sl;
-      pciRxP         : in  slv(7 downto 0);
-      pciRxN         : in  slv(7 downto 0);
-      pciTxP         : out slv(7 downto 0);
-      pciTxN         : out slv(7 downto 0));
+      pciRstL         : in  sl;
+      pciRefClkP      : in  sl;
+      pciRefClkN      : in  sl;
+      pciRxP          : in  slv(7 downto 0);
+      pciRxN          : in  slv(7 downto 0);
+      pciTxP          : out slv(7 downto 0);
+      pciTxN          : out slv(7 downto 0));
 end AlphaDataKu3Core;
 
 architecture mapping of AlphaDataKu3Core is
@@ -239,8 +241,8 @@ begin
          ROGUE_SIM_PORT_NUM_G => ROGUE_SIM_PORT_NUM_G,
          ROGUE_SIM_CH_COUNT_G => ROGUE_SIM_CH_COUNT_G,
          DMA_SIZE_G           => DMA_SIZE_G,
-         DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
-         DESC_ARB_G           => false)  -- Round robin to help with timing
+         DMA_BURST_BYTES_G    => DMA_BURST_BYTES_G,
+         DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G)
       port map (
          axiClk           => sysClock,
          axiRst           => sysReset,
@@ -256,6 +258,7 @@ begin
          axilWriteSlaves  => dmaCtrlWriteSlaves,
          -- DMA Interfaces
          dmaIrq           => dmaIrq,
+         dmaBuffGrpPause  => dmaBuffGrpPause,
          dmaObMasters     => dmaObMasters,
          dmaObSlaves      => dmaObSlaves,
          dmaIbMasters     => dmaIbMasters,

--- a/hardware/AlphaDataKu3/rtl/AlphaDataKu3Core.vhd
+++ b/hardware/AlphaDataKu3/rtl/AlphaDataKu3Core.vhd
@@ -21,11 +21,11 @@
 --
 -------------------------------------------------------------------------------
 -- This file is part of 'axi-pcie-core'.
--- It is subject to the license terms in the LICENSE.txt file found in the 
--- top-level directory of this distribution and at: 
---    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
--- No part of 'axi-pcie-core', including this file, 
--- may be copied, modified, propagated, or distributed except according to 
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'axi-pcie-core', including this file,
+-- may be copied, modified, propagated, or distributed except according to
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 
@@ -59,7 +59,7 @@ entity AlphaDataKu3Core is
       DMA_BURST_BYTES_G    : positive range 256 to 4096  := 256;
       DMA_SIZE_G           : positive range 1 to 8       := 1);
    port (
-      ------------------------      
+      ------------------------
       --  Top Level Interfaces
       ------------------------
       -- DMA Interfaces  (dmaClk domain)
@@ -79,14 +79,14 @@ entity AlphaDataKu3Core is
       appWriteSlave   : in  AxiLiteWriteSlaveType;
       -------------------
       --  Top Level Ports
-      -------------------      
+      -------------------
       -- QSFP[0] Ports
       qsfp0RstL       : out sl;
       qsfp0LpMode     : out sl;
       -- QSFP[1] Ports
       qsfp1RstL       : out sl;
       qsfp1LpMode     : out sl;
-      -- PCIe Ports 
+      -- PCIe Ports
       pciRstL         : in  sl;
       pciRefClkP      : in  sl;
       pciRefClkN      : in  sl;
@@ -145,7 +145,7 @@ begin
 
    ---------------
    -- AXI PCIe PHY
-   ---------------   
+   ---------------
    REAL_PCIE : if (not ROGUE_SIM_EN_G) generate
       U_AxiPciePhy : entity axi_pcie_core.AlphaDataKu3PciePhyWrapper
          generic map (
@@ -168,7 +168,7 @@ begin
             phyWriteSlave  => phyWriteSlave,
             -- Interrupt Interface
             dmaIrq         => dmaIrq,
-            -- PCIe Ports 
+            -- PCIe Ports
             pciRstL        => pciRstL,
             pciRefClkP     => pciRefClkP,
             pciRefClkN     => pciRefClkN,
@@ -190,7 +190,7 @@ begin
 
    ---------------
    -- AXI PCIe REG
-   --------------- 
+   ---------------
    U_REG : entity axi_pcie_core.AxiPcieReg
       generic map (
          TPD_G                => TPD_G,
@@ -233,7 +233,7 @@ begin
 
    ---------------
    -- AXI PCIe DMA
-   ---------------   
+   ---------------
    U_AxiPcieDma : entity axi_pcie_core.AxiPcieDma
       generic map (
          TPD_G                => TPD_G,

--- a/hardware/SlacPgpCardG3/rtl/AxiPciePgpCardG3Core.vhd
+++ b/hardware/SlacPgpCardG3/rtl/AxiPciePgpCardG3Core.vhd
@@ -251,7 +251,7 @@ begin
          ROGUE_SIM_CH_COUNT_G => ROGUE_SIM_CH_COUNT_G,
          DMA_SIZE_G           => DMA_SIZE_G,
          DMA_BURST_BYTES_G    => DMA_BURST_BYTES_G,
-         DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
+         DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_C,
          INT_PIPE_STAGES_G    => INT_PIPE_STAGES_G,
          PIPE_STAGES_G        => PIPE_STAGES_G)
       port map (

--- a/hardware/SlacPgpCardG3/rtl/AxiPciePgpCardG3Core.vhd
+++ b/hardware/SlacPgpCardG3/rtl/AxiPciePgpCardG3Core.vhd
@@ -6,11 +6,11 @@
 -- https://confluence.slac.stanford.edu/display/AIRTRACK/PC_260_101_03_C03
 -------------------------------------------------------------------------------
 -- This file is part of 'axi-pcie-core'.
--- It is subject to the license terms in the LICENSE.txt file found in the 
--- top-level directory of this distribution and at: 
---    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
--- No part of 'axi-pcie-core', including this file, 
--- may be copied, modified, propagated, or distributed except according to 
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'axi-pcie-core', including this file,
+-- may be copied, modified, propagated, or distributed except according to
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 
@@ -45,9 +45,9 @@ entity AxiPciePgpCardG3Core is
       INT_PIPE_STAGES_G    : natural range 0 to 1        := 0;
       PIPE_STAGES_G        : natural range 0 to 1        := 0);
    port (
-      ------------------------      
+      ------------------------
       --  Top Level Interfaces
-      ------------------------    
+      ------------------------
       -- DMA Interfaces (dmaClk domain)
       dmaClk          : out   sl;       -- 125 MHz
       dmaRst          : out   sl;
@@ -66,7 +66,7 @@ entity AxiPciePgpCardG3Core is
       -------------------
       --  Top Level Ports
       -------------------
-      -- Boot Memory Ports 
+      -- Boot Memory Ports
       flashAddr       : out   slv(28 downto 0);
       flashData       : inout slv(15 downto 0);
       flashAdv        : out   sl;
@@ -75,7 +75,7 @@ entity AxiPciePgpCardG3Core is
       flashCeL        : out   sl;
       flashOeL        : out   sl;
       flashWeL        : out   sl;
-      -- PCIe Ports 
+      -- PCIe Ports
       pciRstL         : in    sl;
       pciRefClkP      : in    sl;
       pciRefClkN      : in    sl;
@@ -133,7 +133,7 @@ begin
 
    ---------------
    -- AXI PCIe PHY
-   ---------------   
+   ---------------
    REAL_PCIE : if (not ROGUE_SIM_EN_G) generate
       U_AxiPciePhy : entity axi_pcie_core.AxiPgpCardG3PciePhyWrapper
          generic map (
@@ -156,7 +156,7 @@ begin
             phyWriteSlave  => phyWriteSlave,
             -- Interrupt Interface
             dmaIrq         => dmaIrq,
-            -- PCIe Ports 
+            -- PCIe Ports
             pciRstL        => pciRstL,
             pciRefClkP     => pciRefClkP,
             pciRefClkN     => pciRefClkN,
@@ -178,7 +178,7 @@ begin
 
    ---------------
    -- AXI PCIe REG
-   --------------- 
+   ---------------
    U_REG : entity axi_pcie_core.AxiPcieReg
       generic map (
          TPD_G                => TPD_G,
@@ -208,7 +208,7 @@ begin
          phyReadSlave        => phyReadSlave,
          phyWriteMaster      => phyWriteMaster,
          phyWriteSlave       => phyWriteSlave,
-         -- (Optional) Application AXI-Lite Interfaces      
+         -- (Optional) Application AXI-Lite Interfaces
          appClk              => appClk,
          appRst              => appRst,
          appReadMaster       => appReadMaster,
@@ -218,7 +218,7 @@ begin
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,
-         -- Boot Memory Ports 
+         -- Boot Memory Ports
          bpiAddr             => flashAddr,
          bpiAdv              => flashAdv,
          bpiClk              => flashClk,
@@ -237,12 +237,12 @@ begin
             O  => flashDout(i),         -- Buffer output
             IO => flashData(i),  -- Buffer inout port (connect directly to top-level port)
             I  => flashDin(i),          -- Buffer input
-            T  => flashTri);  -- 3-state enable input, high=input, low=output     
+            T  => flashTri);  -- 3-state enable input, high=input, low=output
    end generate GEN_IOBUF;
 
    ---------------
    -- AXI PCIe DMA
-   ---------------   
+   ---------------
    U_AxiPcieDma : entity axi_pcie_core.AxiPcieDma
       generic map (
          TPD_G                => TPD_G,

--- a/hardware/SlacPgpCardG3/rtl/AxiPciePkg.vhd
+++ b/hardware/SlacPgpCardG3/rtl/AxiPciePkg.vhd
@@ -33,7 +33,7 @@ package AxiPciePkg is
       TSTRB_EN_C    => false,
       TDATA_BYTES_C => 16,              -- 128-bit data interface
       TDEST_BITS_C  => 8,
-      TID_BITS_C    => 0,
+      TID_BITS_C    => 3,
       TKEEP_MODE_C  => TKEEP_COMP_C,
       TUSER_BITS_C  => 4,
       TUSER_MODE_C  => TUSER_FIRST_LAST_C);

--- a/hardware/SlacPgpCardG4/rtl/SlacPgpCardG4Core.vhd
+++ b/hardware/SlacPgpCardG4/rtl/SlacPgpCardG4Core.vhd
@@ -6,11 +6,11 @@
 -- https://confluence.slac.stanford.edu/x/cQbWDw
 -------------------------------------------------------------------------------
 -- This file is part of 'axi-pcie-core'.
--- It is subject to the license terms in the LICENSE.txt file found in the 
--- top-level directory of this distribution and at: 
---    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
--- No part of 'axi-pcie-core', including this file, 
--- may be copied, modified, propagated, or distributed except according to 
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'axi-pcie-core', including this file,
+-- may be copied, modified, propagated, or distributed except according to
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 
@@ -44,7 +44,7 @@ entity SlacPgpCardG4Core is
       DMA_BURST_BYTES_G    : positive range 256 to 4096  := 256;
       DMA_SIZE_G           : positive range 1 to 8       := 1);
    port (
-      ------------------------      
+      ------------------------
       --  Top Level Interfaces
       ------------------------
       -- DMA Interfaces  (dmaClk domain)
@@ -69,16 +69,16 @@ entity SlacPgpCardG4Core is
       appWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
-      -------------------      
+      -------------------
       -- System Ports
       emcClk          : in  sl;
-      -- Boot Memory Ports 
+      -- Boot Memory Ports
       flashCsL        : out sl;
       flashMosi       : out sl;
       flashMiso       : in  sl;
       flashHoldL      : out sl;
       flashWp         : out sl;
-      -- PCIe Ports 
+      -- PCIe Ports
       pciRstL         : in  sl;
       pciRefClkP      : in  sl;
       pciRefClkN      : in  sl;
@@ -149,7 +149,7 @@ begin
 
    ---------------
    -- AXI PCIe PHY
-   ---------------   
+   ---------------
    REAL_PCIE : if (not ROGUE_SIM_EN_G) generate
 
       U_AxiPciePhy : entity axi_pcie_core.SlacPgpCardG4PciePhyWrapper
@@ -173,7 +173,7 @@ begin
             phyWriteSlave  => phyWriteSlave,
             -- Interrupt Interface
             dmaIrq         => dmaIrq,
-            -- PCIe Ports 
+            -- PCIe Ports
             pciRstL        => pciRstL,
             pciRefClkP     => pciRefClkP,
             pciRefClkN     => pciRefClkN,
@@ -210,7 +210,7 @@ begin
 
    ---------------
    -- AXI PCIe REG
-   --------------- 
+   ---------------
    U_REG : entity axi_pcie_core.AxiPcieReg
       generic map (
          TPD_G                => TPD_G,
@@ -252,7 +252,7 @@ begin
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,
-         -- SPI Boot Memory Ports 
+         -- SPI Boot Memory Ports
          spiCsL              => bootCsL,
          spiSck              => bootSck,
          spiMosi             => bootMosi,
@@ -295,7 +295,7 @@ begin
 
    ---------------
    -- AXI PCIe DMA
-   ---------------   
+   ---------------
    U_AxiPcieDma : entity axi_pcie_core.AxiPcieDma
       generic map (
          TPD_G                => TPD_G,

--- a/hardware/SlacPgpCardG4/rtl/SlacPgpCardG4Core.vhd
+++ b/hardware/SlacPgpCardG4/rtl/SlacPgpCardG4Core.vhd
@@ -41,49 +41,51 @@ entity SlacPgpCardG4Core is
       BUILD_INFO_G         : BuildInfoType;
       DMA_AXIS_CONFIG_G    : AxiStreamConfigType;
       DRIVER_TYPE_ID_G     : slv(31 downto 0)            := x"00000000";
+      DMA_BURST_BYTES_G    : positive range 256 to 4096  := 256;
       DMA_SIZE_G           : positive range 1 to 8       := 1);
    port (
       ------------------------      
       --  Top Level Interfaces
       ------------------------
       -- DMA Interfaces  (dmaClk domain)
-      dmaClk         : out sl;
-      dmaRst         : out sl;
-      dmaObMasters   : out AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
-      dmaObSlaves    : in  AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
-      dmaIbMasters   : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
-      dmaIbSlaves    : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
+      dmaClk          : out sl;
+      dmaRst          : out sl;
+      dmaBuffGrpPause : out slv(7 downto 0);
+      dmaObMasters    : out AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
+      dmaObSlaves     : in  AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
+      dmaIbMasters    : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
+      dmaIbSlaves     : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
       -- PIP Interface [0x00080000:0009FFFF] (dmaClk domain)
-      pipIbMaster    : out AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
-      pipIbSlave     : in  AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
-      pipObMaster    : in  AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
-      pipObSlave     : out AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
+      pipIbMaster     : out AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
+      pipIbSlave      : in  AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
+      pipObMaster     : in  AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
+      pipObSlave      : out AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
       -- Application AXI-Lite Interfaces [0x00100000:0x00FFFFFF] (appClk domain)
-      appClk         : in  sl                    := '0';
-      appRst         : in  sl                    := '1';
-      appReadMaster  : out AxiLiteReadMasterType;
-      appReadSlave   : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
-      appWriteMaster : out AxiLiteWriteMasterType;
-      appWriteSlave  : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
+      appClk          : in  sl                    := '0';
+      appRst          : in  sl                    := '1';
+      appReadMaster   : out AxiLiteReadMasterType;
+      appReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      appWriteMaster  : out AxiLiteWriteMasterType;
+      appWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------      
       -- System Ports
-      emcClk         : in  sl;
+      emcClk          : in  sl;
       -- Boot Memory Ports 
-      flashCsL       : out sl;
-      flashMosi      : out sl;
-      flashMiso      : in  sl;
-      flashHoldL     : out sl;
-      flashWp        : out sl;
+      flashCsL        : out sl;
+      flashMosi       : out sl;
+      flashMiso       : in  sl;
+      flashHoldL      : out sl;
+      flashWp         : out sl;
       -- PCIe Ports 
-      pciRstL        : in  sl;
-      pciRefClkP     : in  sl;
-      pciRefClkN     : in  sl;
-      pciRxP         : in  slv(7 downto 0);
-      pciRxN         : in  slv(7 downto 0);
-      pciTxP         : out slv(7 downto 0);
-      pciTxN         : out slv(7 downto 0));
+      pciRstL         : in  sl;
+      pciRefClkP      : in  sl;
+      pciRefClkN      : in  sl;
+      pciRxP          : in  slv(7 downto 0);
+      pciRxN          : in  slv(7 downto 0);
+      pciTxP          : out slv(7 downto 0);
+      pciTxN          : out slv(7 downto 0));
 end SlacPgpCardG4Core;
 
 architecture mapping of SlacPgpCardG4Core is
@@ -301,8 +303,8 @@ begin
          ROGUE_SIM_PORT_NUM_G => ROGUE_SIM_PORT_NUM_G,
          ROGUE_SIM_CH_COUNT_G => ROGUE_SIM_CH_COUNT_G,
          DMA_SIZE_G           => DMA_SIZE_G,
-         DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
-         DESC_ARB_G           => false)  -- Round robin to help with timing
+         DMA_BURST_BYTES_G    => DMA_BURST_BYTES_G,
+         DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G)
       port map (
          axiClk           => sysClock,
          axiRst           => sysReset,
@@ -320,6 +322,7 @@ begin
          axilWriteSlaves  => dmaCtrlWriteSlaves,
          -- DMA Interfaces
          dmaIrq           => dmaIrq,
+         dmaBuffGrpPause  => dmaBuffGrpPause,
          dmaObMasters     => dmaObMasters,
          dmaObSlaves      => dmaObSlaves,
          dmaIbMasters     => dmaIbMasters,

--- a/hardware/XilinxAc701/rtl/AxiPciePkg.vhd
+++ b/hardware/XilinxAc701/rtl/AxiPciePkg.vhd
@@ -33,7 +33,7 @@ package AxiPciePkg is
       TSTRB_EN_C    => false,
       TDATA_BYTES_C => 8,              -- 64-bit data interface
       TDEST_BITS_C  => 8,
-      TID_BITS_C    => 0,
+      TID_BITS_C    => 3,
       TKEEP_MODE_C  => TKEEP_COMP_C,
       TUSER_BITS_C  => 4,
       TUSER_MODE_C  => TUSER_FIRST_LAST_C);

--- a/hardware/XilinxAc701/rtl/XilinxAc701Core.vhd
+++ b/hardware/XilinxAc701/rtl/XilinxAc701Core.vhd
@@ -6,11 +6,11 @@
 -- https://www.xilinx.com/products/boards-and-kits/ac701.html
 -------------------------------------------------------------------------------
 -- This file is part of 'axi-pcie-core'.
--- It is subject to the license terms in the LICENSE.txt file found in the 
--- top-level directory of this distribution and at: 
---    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
--- No part of 'axi-pcie-core', including this file, 
--- may be copied, modified, propagated, or distributed except according to 
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'axi-pcie-core', including this file,
+-- may be copied, modified, propagated, or distributed except according to
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 
@@ -45,9 +45,9 @@ entity XilinxAc701Core is
       INT_PIPE_STAGES_G    : natural range 0 to 1        := 1;
       PIPE_STAGES_G        : natural range 0 to 1        := 1);
    port (
-      ------------------------      
+      ------------------------
       --  Top Level Interfaces
-      ------------------------    
+      ------------------------
       -- DMA Interfaces (dmaClk domain)
       dmaClk          : out sl;         -- 125 MHz
       dmaRst          : out sl;
@@ -65,14 +65,14 @@ entity XilinxAc701Core is
       appWriteSlave   : in  AxiLiteWriteSlaveType;
       -------------------
       --  Top Level Ports
-      -------------------       
+      -------------------
       -- System Ports
       emcClk          : in  sl;
       -- Boot Memory Ports
       bootCsL         : out sl;
       bootMosi        : out sl;
       bootMiso        : in  sl;
-      -- PCIe Ports 
+      -- PCIe Ports
       pciRstL         : in  sl;
       pciRefClkP      : in  sl;
       pciRefClkN      : in  sl;
@@ -134,7 +134,7 @@ begin
 
    ---------------
    -- AXI PCIe PHY
-   ---------------   
+   ---------------
    REAL_PCIE : if (not ROGUE_SIM_EN_G) generate
       U_AxiPciePhy : entity axi_pcie_core.XilinxAc701PciePhyWrapper
          generic map (
@@ -157,7 +157,7 @@ begin
             phyWriteSlave  => phyWriteSlave,
             -- Interrupt Interface
             dmaIrq         => dmaIrq,
-            -- PCIe Ports 
+            -- PCIe Ports
             pciRstL        => pciRstL,
             pciRefClkP     => pciRefClkP,
             pciRefClkN     => pciRefClkN,
@@ -179,7 +179,7 @@ begin
 
    ---------------
    -- AXI PCIe REG
-   --------------- 
+   ---------------
    U_REG : entity axi_pcie_core.AxiPcieReg
       generic map (
          TPD_G                => TPD_G,
@@ -209,7 +209,7 @@ begin
          phyReadSlave        => phyReadSlave,
          phyWriteMaster      => phyWriteMaster,
          phyWriteSlave       => phyWriteSlave,
-         -- (Optional) Application AXI-Lite Interfaces      
+         -- (Optional) Application AXI-Lite Interfaces
          appClk              => appClk,
          appRst              => appRst,
          appReadMaster       => appReadMaster,
@@ -219,7 +219,7 @@ begin
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,
-         -- SPI Boot Memory Ports 
+         -- SPI Boot Memory Ports
          spiCsL              => csL,
          spiSck              => sck,
          spiMosi             => mosi,
@@ -246,13 +246,13 @@ begin
          USRCCLKO  => userCclk,         -- 1-bit input: User CCLK input
          USRCCLKTS => '0',  -- 1-bit input: User CCLK 3-state enable input
          USRDONEO  => '1',  -- 1-bit input: User DONE pin output control
-         USRDONETS => '1');  -- 1-bit input: User DONE 3-state enable output              
+         USRDONETS => '1');  -- 1-bit input: User DONE 3-state enable output
 
    userCclk <= emcClk when(eos = '0') else sck(0);
 
    ---------------
    -- AXI PCIe DMA
-   ---------------   
+   ---------------
    U_AxiPcieDma : entity axi_pcie_core.AxiPcieDma
       generic map (
          TPD_G                => TPD_G,

--- a/hardware/XilinxAc701/rtl/XilinxAc701Core.vhd
+++ b/hardware/XilinxAc701/rtl/XilinxAc701Core.vhd
@@ -40,6 +40,7 @@ entity XilinxAc701Core is
       ROGUE_SIM_CH_COUNT_G : natural range 1 to 256      := 256;
       BUILD_INFO_G         : BuildInfoType;
       DRIVER_TYPE_ID_G     : slv(31 downto 0)            := x"00000000";
+      DMA_BURST_BYTES_G    : positive range 256 to 4096  := 256;
       DMA_SIZE_G           : positive range 1 to 8       := 1;
       INT_PIPE_STAGES_G    : natural range 0 to 1        := 1;
       PIPE_STAGES_G        : natural range 0 to 1        := 1);
@@ -48,36 +49,37 @@ entity XilinxAc701Core is
       --  Top Level Interfaces
       ------------------------    
       -- DMA Interfaces (dmaClk domain)
-      dmaClk         : out sl;          -- 125 MHz
-      dmaRst         : out sl;
-      dmaObMasters   : out AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
-      dmaObSlaves    : in  AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
-      dmaIbMasters   : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
-      dmaIbSlaves    : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
+      dmaClk          : out sl;         -- 125 MHz
+      dmaRst          : out sl;
+      dmaBuffGrpPause : out slv(7 downto 0);
+      dmaObMasters    : out AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
+      dmaObSlaves     : in  AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
+      dmaIbMasters    : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
+      dmaIbSlaves     : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
       -- Application AXI-Lite Interfaces [0x00100000:0x00FFFFFF] (appClk domain)
-      appClk         : in  sl;
-      appRst         : in  sl;
-      appReadMaster  : out AxiLiteReadMasterType;
-      appReadSlave   : in  AxiLiteReadSlaveType;
-      appWriteMaster : out AxiLiteWriteMasterType;
-      appWriteSlave  : in  AxiLiteWriteSlaveType;
+      appClk          : in  sl;
+      appRst          : in  sl;
+      appReadMaster   : out AxiLiteReadMasterType;
+      appReadSlave    : in  AxiLiteReadSlaveType;
+      appWriteMaster  : out AxiLiteWriteMasterType;
+      appWriteSlave   : in  AxiLiteWriteSlaveType;
       -------------------
       --  Top Level Ports
       -------------------       
       -- System Ports
-      emcClk         : in  sl;
+      emcClk          : in  sl;
       -- Boot Memory Ports
-      bootCsL        : out sl;
-      bootMosi       : out sl;
-      bootMiso       : in  sl;
+      bootCsL         : out sl;
+      bootMosi        : out sl;
+      bootMiso        : in  sl;
       -- PCIe Ports 
-      pciRstL        : in  sl;
-      pciRefClkP     : in  sl;
-      pciRefClkN     : in  sl;
-      pciRxP         : in  slv(0 downto 0);
-      pciRxN         : in  slv(0 downto 0);
-      pciTxP         : out slv(0 downto 0);
-      pciTxN         : out slv(0 downto 0));
+      pciRstL         : in  sl;
+      pciRefClkP      : in  sl;
+      pciRefClkN      : in  sl;
+      pciRxP          : in  slv(0 downto 0);
+      pciRxN          : in  slv(0 downto 0);
+      pciTxP          : out slv(0 downto 0);
+      pciTxN          : out slv(0 downto 0));
 end XilinxAc701Core;
 
 architecture mapping of XilinxAc701Core is
@@ -258,8 +260,8 @@ begin
          ROGUE_SIM_PORT_NUM_G => ROGUE_SIM_PORT_NUM_G,
          ROGUE_SIM_CH_COUNT_G => ROGUE_SIM_CH_COUNT_G,
          DMA_SIZE_G           => DMA_SIZE_G,
-         DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_C,
-         DESC_ARB_G           => false,  -- Round robin to help with timing      
+         DMA_BURST_BYTES_G    => DMA_BURST_BYTES_G,
+         DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
          INT_PIPE_STAGES_G    => INT_PIPE_STAGES_G,
          PIPE_STAGES_G        => PIPE_STAGES_G)
       port map (
@@ -277,6 +279,7 @@ begin
          axilWriteSlaves  => dmaCtrlWriteSlaves,
          -- DMA Interfaces
          dmaIrq           => dmaIrq,
+         dmaBuffGrpPause  => dmaBuffGrpPause,
          dmaObMasters     => dmaObMasters,
          dmaObSlaves      => dmaObSlaves,
          dmaIbMasters     => dmaIbMasters,

--- a/hardware/XilinxAc701/rtl/XilinxAc701Core.vhd
+++ b/hardware/XilinxAc701/rtl/XilinxAc701Core.vhd
@@ -261,7 +261,7 @@ begin
          ROGUE_SIM_CH_COUNT_G => ROGUE_SIM_CH_COUNT_G,
          DMA_SIZE_G           => DMA_SIZE_G,
          DMA_BURST_BYTES_G    => DMA_BURST_BYTES_G,
-         DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
+         DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_C,
          INT_PIPE_STAGES_G    => INT_PIPE_STAGES_G,
          PIPE_STAGES_G        => PIPE_STAGES_G)
       port map (

--- a/hardware/XilinxAlveoU200/core/XilinxAlveoU200Core.vhd
+++ b/hardware/XilinxAlveoU200/core/XilinxAlveoU200Core.vhd
@@ -6,11 +6,11 @@
 -- https://www.xilinx.com/products/boards-and-kits/alveo/u200.html
 -------------------------------------------------------------------------------
 -- This file is part of 'axi-pcie-core'.
--- It is subject to the license terms in the LICENSE.txt file found in the 
--- top-level directory of this distribution and at: 
---    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
--- No part of 'axi-pcie-core', including this file, 
--- may be copied, modified, propagated, or distributed except according to 
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'axi-pcie-core', including this file,
+-- may be copied, modified, propagated, or distributed except according to
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 
@@ -44,7 +44,7 @@ entity XilinxAlveoU200Core is
       DMA_BURST_BYTES_G    : positive range 256 to 4096  := 256;
       DMA_SIZE_G           : positive range 1 to 8       := 1);
    port (
-      ------------------------      
+      ------------------------
       --  Top Level Interfaces
       ------------------------
       userClk156      : out sl;
@@ -70,7 +70,7 @@ entity XilinxAlveoU200Core is
       appWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
-      -------------------      
+      -------------------
       -- System Ports
       userClkP        : in  sl;
       userClkN        : in  sl;
@@ -81,7 +81,7 @@ entity XilinxAlveoU200Core is
       qsfpLpMode      : out slv(1 downto 0);
       qsfpModSelL     : out slv(1 downto 0);
       qsfpModPrsL     : in  slv(1 downto 0);
-      -- PCIe Ports 
+      -- PCIe Ports
       pciRstL         : in  sl;
       pciRefClkP      : in  sl;
       pciRefClkN      : in  sl;
@@ -163,7 +163,7 @@ begin
 
    ---------------
    -- AXI PCIe PHY
-   ---------------   
+   ---------------
    REAL_PCIE : if (not ROGUE_SIM_EN_G) generate
 
       U_AxiPciePhy : entity axi_pcie_core.XilinxAlveoU200PciePhyWrapper
@@ -187,7 +187,7 @@ begin
             phyWriteSlave  => phyWriteSlave,
             -- Interrupt Interface
             dmaIrq         => dmaIrq,
-            -- PCIe Ports 
+            -- PCIe Ports
             pciRstL        => pciRstL,
             pciRefClkP     => pciRefClkP,
             pciRefClkN     => pciRefClkN,
@@ -224,7 +224,7 @@ begin
 
    ---------------
    -- AXI PCIe REG
-   --------------- 
+   ---------------
    U_REG : entity axi_pcie_core.AxiPcieReg
       generic map (
          TPD_G                => TPD_G,
@@ -266,7 +266,7 @@ begin
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,
-         -- SPI Boot Memory Ports 
+         -- SPI Boot Memory Ports
          spiCsL              => bootCsL,
          spiSck              => bootSck,
          spiMosi             => bootMosi,
@@ -301,7 +301,7 @@ begin
 
    ---------------
    -- AXI PCIe DMA
-   ---------------   
+   ---------------
    U_AxiPcieDma : entity axi_pcie_core.AxiPcieDma
       generic map (
          TPD_G                => TPD_G,

--- a/hardware/XilinxAlveoU200/core/XilinxAlveoU200Core.vhd
+++ b/hardware/XilinxAlveoU200/core/XilinxAlveoU200Core.vhd
@@ -47,47 +47,48 @@ entity XilinxAlveoU200Core is
       ------------------------      
       --  Top Level Interfaces
       ------------------------
-      userClk156     : out sl;
+      userClk156      : out sl;
       -- DMA Interfaces  (dmaClk domain)
-      dmaClk         : out sl;
-      dmaRst         : out sl;
-      dmaObMasters   : out AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
-      dmaObSlaves    : in  AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
-      dmaIbMasters   : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
-      dmaIbSlaves    : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
+      dmaClk          : out sl;
+      dmaRst          : out sl;
+      dmaBuffGrpPause : out slv(7 downto 0);
+      dmaObMasters    : out AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
+      dmaObSlaves     : in  AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
+      dmaIbMasters    : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
+      dmaIbSlaves     : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
       -- PIP Interface [0x00080000:0009FFFF] (dmaClk domain)
-      pipIbMaster    : out AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
-      pipIbSlave     : in  AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
-      pipObMaster    : in  AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
-      pipObSlave     : out AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
+      pipIbMaster     : out AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
+      pipIbSlave      : in  AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
+      pipObMaster     : in  AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
+      pipObSlave      : out AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
       -- Application AXI-Lite Interfaces [0x00100000:0x00FFFFFF] (appClk domain)
-      appClk         : in  sl                    := '0';
-      appRst         : in  sl                    := '1';
-      appReadMaster  : out AxiLiteReadMasterType;
-      appReadSlave   : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
-      appWriteMaster : out AxiLiteWriteMasterType;
-      appWriteSlave  : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
+      appClk          : in  sl                    := '0';
+      appRst          : in  sl                    := '1';
+      appReadMaster   : out AxiLiteReadMasterType;
+      appReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      appWriteMaster  : out AxiLiteWriteMasterType;
+      appWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------      
       -- System Ports
-      userClkP       : in  sl;
-      userClkN       : in  sl;
+      userClkP        : in  sl;
+      userClkN        : in  sl;
       -- QSFP[1:0] Ports
-      qsfpFs         : out Slv2Array(1 downto 0);
-      qsfpRefClkRst  : out slv(1 downto 0);
-      qsfpRstL       : out slv(1 downto 0);
-      qsfpLpMode     : out slv(1 downto 0);
-      qsfpModSelL    : out slv(1 downto 0);
-      qsfpModPrsL    : in  slv(1 downto 0);
+      qsfpFs          : out Slv2Array(1 downto 0);
+      qsfpRefClkRst   : out slv(1 downto 0);
+      qsfpRstL        : out slv(1 downto 0);
+      qsfpLpMode      : out slv(1 downto 0);
+      qsfpModSelL     : out slv(1 downto 0);
+      qsfpModPrsL     : in  slv(1 downto 0);
       -- PCIe Ports 
-      pciRstL        : in  sl;
-      pciRefClkP     : in  sl;
-      pciRefClkN     : in  sl;
-      pciRxP         : in  slv(15 downto 0);
-      pciRxN         : in  slv(15 downto 0);
-      pciTxP         : out slv(15 downto 0);
-      pciTxN         : out slv(15 downto 0));
+      pciRstL         : in  sl;
+      pciRefClkP      : in  sl;
+      pciRefClkN      : in  sl;
+      pciRxP          : in  slv(15 downto 0);
+      pciRxN          : in  slv(15 downto 0);
+      pciTxP          : out slv(15 downto 0);
+      pciTxN          : out slv(15 downto 0));
 end XilinxAlveoU200Core;
 
 architecture mapping of XilinxAlveoU200Core is
@@ -311,8 +312,7 @@ begin
          DMA_BURST_BYTES_G    => DMA_BURST_BYTES_G,
          DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
          DESC_SYNTH_MODE_G    => "xpm",
-         DESC_MEMORY_TYPE_G   => "uram",
-         DESC_ARB_G           => false)  -- Round robin to help with timing
+         DESC_MEMORY_TYPE_G   => "uram")
       port map (
          axiClk           => sysClock,
          axiRst           => sysReset,
@@ -330,6 +330,7 @@ begin
          axilWriteSlaves  => dmaCtrlWriteSlaves,
          -- DMA Interfaces
          dmaIrq           => dmaIrq,
+         dmaBuffGrpPause  => dmaBuffGrpPause,
          dmaObMasters     => dmaObMasters,
          dmaObSlaves      => dmaObSlaves,
          dmaIbMasters     => dmaIbMasters,

--- a/hardware/XilinxAlveoU250/core/XilinxAlveoU250Core.vhd
+++ b/hardware/XilinxAlveoU250/core/XilinxAlveoU250Core.vhd
@@ -6,11 +6,11 @@
 -- https://www.xilinx.com/products/boards-and-kits/alveo/u250.html
 -------------------------------------------------------------------------------
 -- This file is part of 'axi-pcie-core'.
--- It is subject to the license terms in the LICENSE.txt file found in the 
--- top-level directory of this distribution and at: 
---    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
--- No part of 'axi-pcie-core', including this file, 
--- may be copied, modified, propagated, or distributed except according to 
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'axi-pcie-core', including this file,
+-- may be copied, modified, propagated, or distributed except according to
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 
@@ -44,7 +44,7 @@ entity XilinxAlveoU250Core is
       DMA_BURST_BYTES_G    : positive range 256 to 4096  := 256;
       DMA_SIZE_G           : positive range 1 to 8       := 1);
    port (
-      ------------------------      
+      ------------------------
       --  Top Level Interfaces
       ------------------------
       userClk156      : out sl;
@@ -70,7 +70,7 @@ entity XilinxAlveoU250Core is
       appWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
-      -------------------      
+      -------------------
       -- System Ports
       userClkP        : in  sl;
       userClkN        : in  sl;
@@ -81,7 +81,7 @@ entity XilinxAlveoU250Core is
       qsfpLpMode      : out slv(1 downto 0);
       qsfpModSelL     : out slv(1 downto 0);
       qsfpModPrsL     : in  slv(1 downto 0);
-      -- PCIe Ports 
+      -- PCIe Ports
       pciRstL         : in  sl;
       pciRefClkP      : in  sl;
       pciRefClkN      : in  sl;
@@ -163,7 +163,7 @@ begin
 
    ---------------
    -- AXI PCIe PHY
-   ---------------   
+   ---------------
    REAL_PCIE : if (not ROGUE_SIM_EN_G) generate
 
       U_AxiPciePhy : entity axi_pcie_core.XilinxAlveoU250PciePhyWrapper
@@ -187,7 +187,7 @@ begin
             phyWriteSlave  => phyWriteSlave,
             -- Interrupt Interface
             dmaIrq         => dmaIrq,
-            -- PCIe Ports 
+            -- PCIe Ports
             pciRstL        => pciRstL,
             pciRefClkP     => pciRefClkP,
             pciRefClkN     => pciRefClkN,
@@ -224,7 +224,7 @@ begin
 
    ---------------
    -- AXI PCIe REG
-   --------------- 
+   ---------------
    U_REG : entity axi_pcie_core.AxiPcieReg
       generic map (
          TPD_G                => TPD_G,
@@ -266,7 +266,7 @@ begin
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,
-         -- SPI Boot Memory Ports 
+         -- SPI Boot Memory Ports
          spiCsL              => bootCsL,
          spiSck              => bootSck,
          spiMosi             => bootMosi,
@@ -301,7 +301,7 @@ begin
 
    ---------------
    -- AXI PCIe DMA
-   ---------------   
+   ---------------
    U_AxiPcieDma : entity axi_pcie_core.AxiPcieDma
       generic map (
          TPD_G                => TPD_G,

--- a/hardware/XilinxAlveoU250/core/XilinxAlveoU250Core.vhd
+++ b/hardware/XilinxAlveoU250/core/XilinxAlveoU250Core.vhd
@@ -47,47 +47,48 @@ entity XilinxAlveoU250Core is
       ------------------------      
       --  Top Level Interfaces
       ------------------------
-      userClk156     : out sl;
+      userClk156      : out sl;
       -- DMA Interfaces  (dmaClk domain)
-      dmaClk         : out sl;
-      dmaRst         : out sl;
-      dmaObMasters   : out AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
-      dmaObSlaves    : in  AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
-      dmaIbMasters   : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
-      dmaIbSlaves    : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
+      dmaClk          : out sl;
+      dmaRst          : out sl;
+      dmaBuffGrpPause : out slv(7 downto 0);
+      dmaObMasters    : out AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
+      dmaObSlaves     : in  AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
+      dmaIbMasters    : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
+      dmaIbSlaves     : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
       -- PIP Interface [0x00080000:0009FFFF] (dmaClk domain)
-      pipIbMaster    : out AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
-      pipIbSlave     : in  AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
-      pipObMaster    : in  AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
-      pipObSlave     : out AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
+      pipIbMaster     : out AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
+      pipIbSlave      : in  AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
+      pipObMaster     : in  AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
+      pipObSlave      : out AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
       -- Application AXI-Lite Interfaces [0x00100000:0x00FFFFFF] (appClk domain)
-      appClk         : in  sl                    := '0';
-      appRst         : in  sl                    := '1';
-      appReadMaster  : out AxiLiteReadMasterType;
-      appReadSlave   : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
-      appWriteMaster : out AxiLiteWriteMasterType;
-      appWriteSlave  : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
+      appClk          : in  sl                    := '0';
+      appRst          : in  sl                    := '1';
+      appReadMaster   : out AxiLiteReadMasterType;
+      appReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      appWriteMaster  : out AxiLiteWriteMasterType;
+      appWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------      
       -- System Ports
-      userClkP       : in  sl;
-      userClkN       : in  sl;
+      userClkP        : in  sl;
+      userClkN        : in  sl;
       -- QSFP[1:0] Ports
-      qsfpFs         : out Slv2Array(1 downto 0);
-      qsfpRefClkRst  : out slv(1 downto 0);
-      qsfpRstL       : out slv(1 downto 0);
-      qsfpLpMode     : out slv(1 downto 0);
-      qsfpModSelL    : out slv(1 downto 0);
-      qsfpModPrsL    : in  slv(1 downto 0);
+      qsfpFs          : out Slv2Array(1 downto 0);
+      qsfpRefClkRst   : out slv(1 downto 0);
+      qsfpRstL        : out slv(1 downto 0);
+      qsfpLpMode      : out slv(1 downto 0);
+      qsfpModSelL     : out slv(1 downto 0);
+      qsfpModPrsL     : in  slv(1 downto 0);
       -- PCIe Ports 
-      pciRstL        : in  sl;
-      pciRefClkP     : in  sl;
-      pciRefClkN     : in  sl;
-      pciRxP         : in  slv(15 downto 0);
-      pciRxN         : in  slv(15 downto 0);
-      pciTxP         : out slv(15 downto 0);
-      pciTxN         : out slv(15 downto 0));
+      pciRstL         : in  sl;
+      pciRefClkP      : in  sl;
+      pciRefClkN      : in  sl;
+      pciRxP          : in  slv(15 downto 0);
+      pciRxN          : in  slv(15 downto 0);
+      pciTxP          : out slv(15 downto 0);
+      pciTxN          : out slv(15 downto 0));
 end XilinxAlveoU250Core;
 
 architecture mapping of XilinxAlveoU250Core is
@@ -311,8 +312,7 @@ begin
          DMA_BURST_BYTES_G    => DMA_BURST_BYTES_G,
          DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
          DESC_SYNTH_MODE_G    => "xpm",
-         DESC_MEMORY_TYPE_G   => "uram",
-         DESC_ARB_G           => false)  -- Round robin to help with timing
+         DESC_MEMORY_TYPE_G   => "uram")
       port map (
          axiClk           => sysClock,
          axiRst           => sysReset,
@@ -330,6 +330,7 @@ begin
          axilWriteSlaves  => dmaCtrlWriteSlaves,
          -- DMA Interfaces
          dmaIrq           => dmaIrq,
+         dmaBuffGrpPause  => dmaBuffGrpPause,
          dmaObMasters     => dmaObMasters,
          dmaObSlaves      => dmaObSlaves,
          dmaIbMasters     => dmaIbMasters,

--- a/hardware/XilinxAlveoU280/pcie-3x16/rtl/XilinxAlveoU280Core.vhd
+++ b/hardware/XilinxAlveoU280/pcie-3x16/rtl/XilinxAlveoU280Core.vhd
@@ -47,45 +47,46 @@ entity XilinxAlveoU280Core is
       ------------------------      
       --  Top Level Interfaces
       ------------------------
-      userClk156     : out sl;
+      userClk156      : out sl;
       -- DMA Interfaces  (dmaClk domain)
-      dmaClk         : out sl;
-      dmaRst         : out sl;
-      dmaObMasters   : out AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
-      dmaObSlaves    : in  AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
-      dmaIbMasters   : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
-      dmaIbSlaves    : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
+      dmaClk          : out sl;
+      dmaRst          : out sl;
+      dmaBuffGrpPause : out slv(7 downto 0);
+      dmaObMasters    : out AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
+      dmaObSlaves     : in  AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
+      dmaIbMasters    : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
+      dmaIbSlaves     : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
       -- PIP Interface [0x00080000:0009FFFF] (dmaClk domain)
-      pipIbMaster    : out AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
-      pipIbSlave     : in  AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
-      pipObMaster    : in  AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
-      pipObSlave     : out AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
+      pipIbMaster     : out AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
+      pipIbSlave      : in  AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
+      pipObMaster     : in  AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
+      pipObSlave      : out AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
       -- Application AXI-Lite Interfaces [0x00100000:0x00FFFFFF] (appClk domain)
-      appClk         : in  sl                    := '0';
-      appRst         : in  sl                    := '1';
-      appReadMaster  : out AxiLiteReadMasterType;
-      appReadSlave   : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
-      appWriteMaster : out AxiLiteWriteMasterType;
-      appWriteSlave  : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
+      appClk          : in  sl                    := '0';
+      appRst          : in  sl                    := '1';
+      appReadMaster   : out AxiLiteReadMasterType;
+      appReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      appWriteMaster  : out AxiLiteWriteMasterType;
+      appWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------      
       -- System Ports
-      userClkP       : in  sl;
-      userClkN       : in  sl;
+      userClkP        : in  sl;
+      userClkN        : in  sl;
       -- QSFP[1:0] Ports
-      qsfpRstL       : out slv(1 downto 0);
-      qsfpLpMode     : out slv(1 downto 0);
-      qsfpModSelL    : out slv(1 downto 0);
-      qsfpModPrsL    : in  slv(1 downto 0);
+      qsfpRstL        : out slv(1 downto 0);
+      qsfpLpMode      : out slv(1 downto 0);
+      qsfpModSelL     : out slv(1 downto 0);
+      qsfpModPrsL     : in  slv(1 downto 0);
       -- PCIe Ports 
-      pciRstL        : in  sl;
-      pciRefClkP     : in  slv(1 downto 0);
-      pciRefClkN     : in  slv(1 downto 0);
-      pciRxP         : in  slv(15 downto 0);
-      pciRxN         : in  slv(15 downto 0);
-      pciTxP         : out slv(15 downto 0);
-      pciTxN         : out slv(15 downto 0));
+      pciRstL         : in  sl;
+      pciRefClkP      : in  slv(1 downto 0);
+      pciRefClkN      : in  slv(1 downto 0);
+      pciRxP          : in  slv(15 downto 0);
+      pciRxN          : in  slv(15 downto 0);
+      pciTxP          : out slv(15 downto 0);
+      pciTxN          : out slv(15 downto 0));
 end XilinxAlveoU280Core;
 
 architecture mapping of XilinxAlveoU280Core is
@@ -307,8 +308,7 @@ begin
          DMA_BURST_BYTES_G    => DMA_BURST_BYTES_G,
          DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
          DESC_SYNTH_MODE_G    => "xpm",
-         DESC_MEMORY_TYPE_G   => "uram",
-         DESC_ARB_G           => false)  -- Round robin to help with timing
+         DESC_MEMORY_TYPE_G   => "uram")
       port map (
          axiClk           => sysClock,
          axiRst           => sysReset,
@@ -326,6 +326,7 @@ begin
          axilWriteSlaves  => dmaCtrlWriteSlaves,
          -- DMA Interfaces
          dmaIrq           => dmaIrq,
+         dmaBuffGrpPause  => dmaBuffGrpPause,
          dmaObMasters     => dmaObMasters,
          dmaObSlaves      => dmaObSlaves,
          dmaIbMasters     => dmaIbMasters,

--- a/hardware/XilinxAlveoU280/pcie-3x16/rtl/XilinxAlveoU280Core.vhd
+++ b/hardware/XilinxAlveoU280/pcie-3x16/rtl/XilinxAlveoU280Core.vhd
@@ -6,11 +6,11 @@
 -- https://www.xilinx.com/products/boards-and-kits/alveo/u280.html
 -------------------------------------------------------------------------------
 -- This file is part of 'axi-pcie-core'.
--- It is subject to the license terms in the LICENSE.txt file found in the 
--- top-level directory of this distribution and at: 
---    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
--- No part of 'axi-pcie-core', including this file, 
--- may be copied, modified, propagated, or distributed except according to 
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'axi-pcie-core', including this file,
+-- may be copied, modified, propagated, or distributed except according to
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 
@@ -44,7 +44,7 @@ entity XilinxAlveoU280Core is
       DMA_BURST_BYTES_G    : positive range 256 to 4096  := 256;
       DMA_SIZE_G           : positive range 1 to 8       := 1);
    port (
-      ------------------------      
+      ------------------------
       --  Top Level Interfaces
       ------------------------
       userClk156      : out sl;
@@ -70,7 +70,7 @@ entity XilinxAlveoU280Core is
       appWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
-      -------------------      
+      -------------------
       -- System Ports
       userClkP        : in  sl;
       userClkN        : in  sl;
@@ -79,7 +79,7 @@ entity XilinxAlveoU280Core is
       qsfpLpMode      : out slv(1 downto 0);
       qsfpModSelL     : out slv(1 downto 0);
       qsfpModPrsL     : in  slv(1 downto 0);
-      -- PCIe Ports 
+      -- PCIe Ports
       pciRstL         : in  sl;
       pciRefClkP      : in  slv(1 downto 0);
       pciRefClkN      : in  slv(1 downto 0);
@@ -159,7 +159,7 @@ begin
 
    ---------------
    -- AXI PCIe PHY
-   ---------------   
+   ---------------
    REAL_PCIE : if (not ROGUE_SIM_EN_G) generate
 
       U_AxiPciePhy : entity axi_pcie_core.XilinxAlveoU280PciePhyWrapper
@@ -183,7 +183,7 @@ begin
             phyWriteSlave  => phyWriteSlave,
             -- Interrupt Interface
             dmaIrq         => dmaIrq,
-            -- PCIe Ports 
+            -- PCIe Ports
             pciRstL        => pciRstL,
             pciRefClkP     => pciRefClkP,
             pciRefClkN     => pciRefClkN,
@@ -220,7 +220,7 @@ begin
 
    ---------------
    -- AXI PCIe REG
-   --------------- 
+   ---------------
    U_REG : entity axi_pcie_core.AxiPcieReg
       generic map (
          TPD_G                => TPD_G,
@@ -262,7 +262,7 @@ begin
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,
-         -- SPI Boot Memory Ports 
+         -- SPI Boot Memory Ports
          spiCsL              => bootCsL,
          spiSck              => bootSck,
          spiMosi             => bootMosi,
@@ -297,7 +297,7 @@ begin
 
    ---------------
    -- AXI PCIe DMA
-   ---------------   
+   ---------------
    U_AxiPcieDma : entity axi_pcie_core.AxiPcieDma
       generic map (
          TPD_G                => TPD_G,

--- a/hardware/XilinxAlveoU50/pcie-3x16/rtl/XilinxAlveoU50Core.vhd
+++ b/hardware/XilinxAlveoU50/pcie-3x16/rtl/XilinxAlveoU50Core.vhd
@@ -47,40 +47,41 @@ entity XilinxAlveoU50Core is
       ------------------------      
       --  Top Level Interfaces
       ------------------------
-      userClk156     : out sl;
+      userClk156      : out sl;
       -- DMA Interfaces  (dmaClk domain)
-      dmaClk         : out sl;
-      dmaRst         : out sl;
-      dmaObMasters   : out AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
-      dmaObSlaves    : in  AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
-      dmaIbMasters   : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
-      dmaIbSlaves    : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
+      dmaClk          : out sl;
+      dmaRst          : out sl;
+      dmaBuffGrpPause : out slv(7 downto 0);
+      dmaObMasters    : out AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
+      dmaObSlaves     : in  AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
+      dmaIbMasters    : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
+      dmaIbSlaves     : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
       -- PIP Interface [0x00080000:0009FFFF] (dmaClk domain)
-      pipIbMaster    : out AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
-      pipIbSlave     : in  AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
-      pipObMaster    : in  AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
-      pipObSlave     : out AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
+      pipIbMaster     : out AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
+      pipIbSlave      : in  AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
+      pipObMaster     : in  AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
+      pipObSlave      : out AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
       -- Application AXI-Lite Interfaces [0x00100000:0x00FFFFFF] (appClk domain)
-      appClk         : in  sl                    := '0';
-      appRst         : in  sl                    := '1';
-      appReadMaster  : out AxiLiteReadMasterType;
-      appReadSlave   : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
-      appWriteMaster : out AxiLiteWriteMasterType;
-      appWriteSlave  : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
+      appClk          : in  sl                    := '0';
+      appRst          : in  sl                    := '1';
+      appReadMaster   : out AxiLiteReadMasterType;
+      appReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      appWriteMaster  : out AxiLiteWriteMasterType;
+      appWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------      
       -- System Ports
-      userClkP       : in  sl;
-      userClkN       : in  sl;
+      userClkP        : in  sl;
+      userClkN        : in  sl;
       -- PCIe Ports 
-      pciRstL        : in  sl;
-      pciRefClkP     : in  slv(1 downto 0);
-      pciRefClkN     : in  slv(1 downto 0);
-      pciRxP         : in  slv(15 downto 0);
-      pciRxN         : in  slv(15 downto 0);
-      pciTxP         : out slv(15 downto 0);
-      pciTxN         : out slv(15 downto 0));
+      pciRstL         : in  sl;
+      pciRefClkP      : in  slv(1 downto 0);
+      pciRefClkN      : in  slv(1 downto 0);
+      pciRxP          : in  slv(15 downto 0);
+      pciRxN          : in  slv(15 downto 0);
+      pciTxP          : out slv(15 downto 0);
+      pciTxN          : out slv(15 downto 0));
 end XilinxAlveoU50Core;
 
 architecture mapping of XilinxAlveoU50Core is
@@ -298,8 +299,7 @@ begin
          DMA_BURST_BYTES_G    => DMA_BURST_BYTES_G,
          DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
          DESC_SYNTH_MODE_G    => "xpm",
-         DESC_MEMORY_TYPE_G   => "uram",
-         DESC_ARB_G           => false)  -- Round robin to help with timing
+         DESC_MEMORY_TYPE_G   => "uram")
       port map (
          axiClk           => sysClock,
          axiRst           => sysReset,
@@ -317,6 +317,7 @@ begin
          axilWriteSlaves  => dmaCtrlWriteSlaves,
          -- DMA Interfaces
          dmaIrq           => dmaIrq,
+         dmaBuffGrpPause  => dmaBuffGrpPause,
          dmaObMasters     => dmaObMasters,
          dmaObSlaves      => dmaObSlaves,
          dmaIbMasters     => dmaIbMasters,

--- a/hardware/XilinxAlveoU50/pcie-3x16/rtl/XilinxAlveoU50Core.vhd
+++ b/hardware/XilinxAlveoU50/pcie-3x16/rtl/XilinxAlveoU50Core.vhd
@@ -6,11 +6,11 @@
 -- https://www.xilinx.com/products/boards-and-kits/alveo/u50.html
 -------------------------------------------------------------------------------
 -- This file is part of 'axi-pcie-core'.
--- It is subject to the license terms in the LICENSE.txt file found in the 
--- top-level directory of this distribution and at: 
---    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
--- No part of 'axi-pcie-core', including this file, 
--- may be copied, modified, propagated, or distributed except according to 
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'axi-pcie-core', including this file,
+-- may be copied, modified, propagated, or distributed except according to
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 
@@ -44,7 +44,7 @@ entity XilinxAlveoU50Core is
       DMA_BURST_BYTES_G    : positive range 256 to 4096  := 256;
       DMA_SIZE_G           : positive range 1 to 8       := 1);
    port (
-      ------------------------      
+      ------------------------
       --  Top Level Interfaces
       ------------------------
       userClk156      : out sl;
@@ -70,11 +70,11 @@ entity XilinxAlveoU50Core is
       appWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
-      -------------------      
+      -------------------
       -- System Ports
       userClkP        : in  sl;
       userClkN        : in  sl;
-      -- PCIe Ports 
+      -- PCIe Ports
       pciRstL         : in  sl;
       pciRefClkP      : in  slv(1 downto 0);
       pciRefClkN      : in  slv(1 downto 0);
@@ -150,7 +150,7 @@ begin
 
    ---------------
    -- AXI PCIe PHY
-   ---------------   
+   ---------------
    REAL_PCIE : if (not ROGUE_SIM_EN_G) generate
 
       U_AxiPciePhy : entity axi_pcie_core.XilinxAlveoU50PciePhyWrapper
@@ -174,7 +174,7 @@ begin
             phyWriteSlave  => phyWriteSlave,
             -- Interrupt Interface
             dmaIrq         => dmaIrq,
-            -- PCIe Ports 
+            -- PCIe Ports
             pciRstL        => pciRstL,
             pciRefClkP     => pciRefClkP,
             pciRefClkN     => pciRefClkN,
@@ -211,7 +211,7 @@ begin
 
    ---------------
    -- AXI PCIe REG
-   --------------- 
+   ---------------
    U_REG : entity axi_pcie_core.AxiPcieReg
       generic map (
          TPD_G                => TPD_G,
@@ -253,7 +253,7 @@ begin
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,
-         -- SPI Boot Memory Ports 
+         -- SPI Boot Memory Ports
          spiCsL              => bootCsL,
          spiSck              => bootSck,
          spiMosi             => bootMosi,
@@ -288,7 +288,7 @@ begin
 
    ---------------
    -- AXI PCIe DMA
-   ---------------   
+   ---------------
    U_AxiPcieDma : entity axi_pcie_core.AxiPcieDma
       generic map (
          TPD_G                => TPD_G,

--- a/hardware/XilinxAlveoU50/ruckus.tcl
+++ b/hardware/XilinxAlveoU50/ruckus.tcl
@@ -1,8 +1,8 @@
 # Load RUCKUS environment and library
 source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 
-# Check for version 2019.2 of Vivado (or later)
-if { [VersionCheck 2019.2] < 0 } {exit -1}
+# Check for version 2020.1 of Vivado (or later)
+if { [VersionCheck 2020.1] < 0 } {exit -1}
 
 # Load shared source code
 loadRuckusTcl "$::DIR_PATH/../../shared"

--- a/hardware/XilinxKc705/rtl/AxiPciePkg.vhd
+++ b/hardware/XilinxKc705/rtl/AxiPciePkg.vhd
@@ -33,7 +33,7 @@ package AxiPciePkg is
       TSTRB_EN_C    => false,
       TDATA_BYTES_C => 16,              -- 128-bit data interface
       TDEST_BITS_C  => 8,
-      TID_BITS_C    => 0,
+      TID_BITS_C    => 3,
       TKEEP_MODE_C  => TKEEP_COMP_C,
       TUSER_BITS_C  => 4,
       TUSER_MODE_C  => TUSER_FIRST_LAST_C);

--- a/hardware/XilinxKc705/rtl/XilinxKc705Core.vhd
+++ b/hardware/XilinxKc705/rtl/XilinxKc705Core.vhd
@@ -25,7 +25,6 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
 
-
 library surf;
 use surf.StdRtlPkg.all;
 use surf.AxiPkg.all;
@@ -46,6 +45,7 @@ entity XilinxKc705Core is
       ROGUE_SIM_CH_COUNT_G : natural range 1 to 256      := 256;
       BUILD_INFO_G         : BuildInfoType;
       DRIVER_TYPE_ID_G     : slv(31 downto 0)            := x"00000000";
+      DMA_BURST_BYTES_G    : positive range 256 to 4096  := 256;
       DMA_SIZE_G           : positive range 1 to 8       := 1;
       INT_PIPE_STAGES_G    : natural range 0 to 1        := 0;
       PIPE_STAGES_G        : natural range 0 to 1        := 0);
@@ -54,36 +54,37 @@ entity XilinxKc705Core is
       --  Top Level Interfaces
       ------------------------    
       -- DMA Interfaces (dmaClk domain)
-      dmaClk         : out sl;          -- 125 MHz
-      dmaRst         : out sl;
-      dmaObMasters   : out AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
-      dmaObSlaves    : in  AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
-      dmaIbMasters   : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
-      dmaIbSlaves    : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
+      dmaClk          : out sl;         -- 125 MHz
+      dmaRst          : out sl;
+      dmaBuffGrpPause : out slv(7 downto 0);
+      dmaObMasters    : out AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
+      dmaObSlaves     : in  AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
+      dmaIbMasters    : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
+      dmaIbSlaves     : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
       -- Application AXI-Lite Interfaces [0x00100000:0x00FFFFFF] (appClk domain)
-      appClk         : in  sl;
-      appRst         : in  sl;
-      appReadMaster  : out AxiLiteReadMasterType;
-      appReadSlave   : in  AxiLiteReadSlaveType;
-      appWriteMaster : out AxiLiteWriteMasterType;
-      appWriteSlave  : in  AxiLiteWriteSlaveType;
+      appClk          : in  sl;
+      appRst          : in  sl;
+      appReadMaster   : out AxiLiteReadMasterType;
+      appReadSlave    : in  AxiLiteReadSlaveType;
+      appWriteMaster  : out AxiLiteWriteMasterType;
+      appWriteSlave   : in  AxiLiteWriteSlaveType;
       -------------------
       --  Top Level Ports
       -------------------       
       -- System Ports
-      emcClk         : in  sl;
+      emcClk          : in  sl;
       -- Boot Memory Ports
-      bootCsL        : out sl;
-      bootMosi       : out sl;
-      bootMiso       : in  sl;
+      bootCsL         : out sl;
+      bootMosi        : out sl;
+      bootMiso        : in  sl;
       -- PCIe Ports 
-      pciRstL        : in  sl;
-      pciRefClkP     : in  sl;
-      pciRefClkN     : in  sl;
-      pciRxP         : in  slv(3 downto 0);
-      pciRxN         : in  slv(3 downto 0);
-      pciTxP         : out slv(3 downto 0);
-      pciTxN         : out slv(3 downto 0));
+      pciRstL         : in  sl;
+      pciRefClkP      : in  sl;
+      pciRefClkN      : in  sl;
+      pciRxP          : in  slv(3 downto 0);
+      pciRxN          : in  slv(3 downto 0);
+      pciTxP          : out slv(3 downto 0);
+      pciTxN          : out slv(3 downto 0));
 end XilinxKc705Core;
 
 architecture mapping of XilinxKc705Core is
@@ -264,8 +265,8 @@ begin
          ROGUE_SIM_PORT_NUM_G => ROGUE_SIM_PORT_NUM_G,
          ROGUE_SIM_CH_COUNT_G => ROGUE_SIM_CH_COUNT_G,
          DMA_SIZE_G           => DMA_SIZE_G,
-         DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_C,
-         DESC_ARB_G           => false,  -- Round robin to help with timing      
+         DMA_BURST_BYTES_G    => DMA_BURST_BYTES_G,
+         DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
          INT_PIPE_STAGES_G    => INT_PIPE_STAGES_G,
          PIPE_STAGES_G        => PIPE_STAGES_G)
       port map (
@@ -283,6 +284,7 @@ begin
          axilWriteSlaves  => dmaCtrlWriteSlaves,
          -- DMA Interfaces
          dmaIrq           => dmaIrq,
+         dmaBuffGrpPause  => dmaBuffGrpPause,
          dmaObMasters     => dmaObMasters,
          dmaObSlaves      => dmaObSlaves,
          dmaIbMasters     => dmaIbMasters,

--- a/hardware/XilinxKc705/rtl/XilinxKc705Core.vhd
+++ b/hardware/XilinxKc705/rtl/XilinxKc705Core.vhd
@@ -7,16 +7,16 @@
 -- https://www.xilinx.com/products/boards-and-kits/kc705.html
 --
 -- Note: Using the QSPI (not BPI) for booting from PROM.
---       J3 needs to have the jumper installed 
+--       J3 needs to have the jumper installed
 --       SW13 needs to be in the "00001" position to set FPGA.M[2:0] = "001"
 --
 -------------------------------------------------------------------------------
 -- This file is part of 'axi-pcie-core'.
--- It is subject to the license terms in the LICENSE.txt file found in the 
--- top-level directory of this distribution and at: 
---    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
--- No part of 'axi-pcie-core', including this file, 
--- may be copied, modified, propagated, or distributed except according to 
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'axi-pcie-core', including this file,
+-- may be copied, modified, propagated, or distributed except according to
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 
@@ -50,9 +50,9 @@ entity XilinxKc705Core is
       INT_PIPE_STAGES_G    : natural range 0 to 1        := 0;
       PIPE_STAGES_G        : natural range 0 to 1        := 0);
    port (
-      ------------------------      
+      ------------------------
       --  Top Level Interfaces
-      ------------------------    
+      ------------------------
       -- DMA Interfaces (dmaClk domain)
       dmaClk          : out sl;         -- 125 MHz
       dmaRst          : out sl;
@@ -70,14 +70,14 @@ entity XilinxKc705Core is
       appWriteSlave   : in  AxiLiteWriteSlaveType;
       -------------------
       --  Top Level Ports
-      -------------------       
+      -------------------
       -- System Ports
       emcClk          : in  sl;
       -- Boot Memory Ports
       bootCsL         : out sl;
       bootMosi        : out sl;
       bootMiso        : in  sl;
-      -- PCIe Ports 
+      -- PCIe Ports
       pciRstL         : in  sl;
       pciRefClkP      : in  sl;
       pciRefClkN      : in  sl;
@@ -139,7 +139,7 @@ begin
 
    ---------------
    -- AXI PCIe PHY
-   ---------------   
+   ---------------
    REAL_PCIE : if (not ROGUE_SIM_EN_G) generate
       U_AxiPciePhy : entity axi_pcie_core.XilinxKc705PciePhyWrapper
          generic map (
@@ -162,7 +162,7 @@ begin
             phyWriteSlave  => phyWriteSlave,
             -- Interrupt Interface
             dmaIrq         => dmaIrq,
-            -- PCIe Ports 
+            -- PCIe Ports
             pciRstL        => pciRstL,
             pciRefClkP     => pciRefClkP,
             pciRefClkN     => pciRefClkN,
@@ -184,7 +184,7 @@ begin
 
    ---------------
    -- AXI PCIe REG
-   --------------- 
+   ---------------
    U_REG : entity axi_pcie_core.AxiPcieReg
       generic map (
          TPD_G                => TPD_G,
@@ -214,7 +214,7 @@ begin
          phyReadSlave        => phyReadSlave,
          phyWriteMaster      => phyWriteMaster,
          phyWriteSlave       => phyWriteSlave,
-         -- (Optional) Application AXI-Lite Interfaces      
+         -- (Optional) Application AXI-Lite Interfaces
          appClk              => appClk,
          appRst              => appRst,
          appReadMaster       => appReadMaster,
@@ -224,7 +224,7 @@ begin
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,
-         -- SPI Boot Memory Ports 
+         -- SPI Boot Memory Ports
          spiCsL              => csL,
          spiSck              => sck,
          spiMosi             => mosi,
@@ -251,13 +251,13 @@ begin
          USRCCLKO  => userCclk,         -- 1-bit input: User CCLK input
          USRCCLKTS => '0',  -- 1-bit input: User CCLK 3-state enable input
          USRDONEO  => '1',  -- 1-bit input: User DONE pin output control
-         USRDONETS => '1');  -- 1-bit input: User DONE 3-state enable output              
+         USRDONETS => '1');  -- 1-bit input: User DONE 3-state enable output
 
    userCclk <= emcClk when(eos = '0') else sck(0);
 
    ---------------
    -- AXI PCIe DMA
-   ---------------   
+   ---------------
    U_AxiPcieDma : entity axi_pcie_core.AxiPcieDma
       generic map (
          TPD_G                => TPD_G,

--- a/hardware/XilinxKc705/rtl/XilinxKc705Core.vhd
+++ b/hardware/XilinxKc705/rtl/XilinxKc705Core.vhd
@@ -266,7 +266,7 @@ begin
          ROGUE_SIM_CH_COUNT_G => ROGUE_SIM_CH_COUNT_G,
          DMA_SIZE_G           => DMA_SIZE_G,
          DMA_BURST_BYTES_G    => DMA_BURST_BYTES_G,
-         DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
+         DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_C,
          INT_PIPE_STAGES_G    => INT_PIPE_STAGES_G,
          PIPE_STAGES_G        => PIPE_STAGES_G)
       port map (

--- a/hardware/XilinxKcu105/rtl/XilinxKcu105Core.vhd
+++ b/hardware/XilinxKcu105/rtl/XilinxKcu105Core.vhd
@@ -6,11 +6,11 @@
 -- https://www.xilinx.com/products/boards-and-kits/kcu105.html
 -------------------------------------------------------------------------------
 -- This file is part of 'axi-pcie-core'.
--- It is subject to the license terms in the LICENSE.txt file found in the 
--- top-level directory of this distribution and at: 
---    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
--- No part of 'axi-pcie-core', including this file, 
--- may be copied, modified, propagated, or distributed except according to 
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'axi-pcie-core', including this file,
+-- may be copied, modified, propagated, or distributed except according to
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 
@@ -44,7 +44,7 @@ entity XilinxKcu105Core is
       DMA_BURST_BYTES_G    : positive range 256 to 4096  := 256;
       DMA_SIZE_G           : positive range 1 to 8       := 1);
    port (
-      ------------------------      
+      ------------------------
       --  Top Level Interfaces
       ------------------------
       -- DMA Interfaces  (dmaClk domain)
@@ -64,16 +64,16 @@ entity XilinxKcu105Core is
       appWriteSlave   : in  AxiLiteWriteSlaveType;
       -------------------
       --  Top Level Ports
-      -------------------    
+      -------------------
       -- System Ports
       emcClk          : in  sl;
-      -- Boot Memory Ports 
+      -- Boot Memory Ports
       flashCsL        : out sl;
       flashMosi       : out sl;
       flashMiso       : in  sl;
       flashHoldL      : out sl;
       flashWp         : out sl;
-      -- PCIe Ports 
+      -- PCIe Ports
       pciRstL         : in  sl;
       pciRefClkP      : in  sl;
       pciRefClkN      : in  sl;
@@ -139,7 +139,7 @@ begin
 
    ---------------
    -- AXI PCIe PHY
-   ---------------   
+   ---------------
    REAL_PCIE : if (not ROGUE_SIM_EN_G) generate
       U_AxiPciePhy : entity axi_pcie_core.XilinxKcu105PciePhyWrapper
          generic map (
@@ -162,7 +162,7 @@ begin
             phyWriteSlave  => phyWriteSlave,
             -- Interrupt Interface
             dmaIrq         => dmaIrq,
-            -- PCIe Ports 
+            -- PCIe Ports
             pciRstL        => pciRstL,
             pciRefClkP     => pciRefClkP,
             pciRefClkN     => pciRefClkN,
@@ -184,7 +184,7 @@ begin
 
    ---------------
    -- AXI PCIe REG
-   --------------- 
+   ---------------
    U_REG : entity axi_pcie_core.AxiPcieReg
       generic map (
          TPD_G                => TPD_G,
@@ -224,7 +224,7 @@ begin
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,
-         -- SPI Boot Memory Ports 
+         -- SPI Boot Memory Ports
          spiCsL              => bootCsL,
          spiSck              => bootSck,
          spiMosi             => bootMosi,
@@ -267,7 +267,7 @@ begin
 
    ---------------
    -- AXI PCIe DMA
-   ---------------   
+   ---------------
    U_AxiPcieDma : entity axi_pcie_core.AxiPcieDma
       generic map (
          TPD_G                => TPD_G,

--- a/hardware/XilinxKcu105/rtl/XilinxKcu105Core.vhd
+++ b/hardware/XilinxKcu105/rtl/XilinxKcu105Core.vhd
@@ -41,44 +41,46 @@ entity XilinxKcu105Core is
       BUILD_INFO_G         : BuildInfoType;
       DMA_AXIS_CONFIG_G    : AxiStreamConfigType;
       DRIVER_TYPE_ID_G     : slv(31 downto 0)            := x"00000000";
+      DMA_BURST_BYTES_G    : positive range 256 to 4096  := 256;
       DMA_SIZE_G           : positive range 1 to 8       := 1);
    port (
       ------------------------      
       --  Top Level Interfaces
       ------------------------
       -- DMA Interfaces  (dmaClk domain)
-      dmaClk         : out sl;
-      dmaRst         : out sl;
-      dmaObMasters   : out AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
-      dmaObSlaves    : in  AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
-      dmaIbMasters   : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
-      dmaIbSlaves    : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
+      dmaClk          : out sl;
+      dmaRst          : out sl;
+      dmaBuffGrpPause : out slv(7 downto 0);
+      dmaObMasters    : out AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
+      dmaObSlaves     : in  AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
+      dmaIbMasters    : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
+      dmaIbSlaves     : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
       -- Application AXI-Lite Interfaces [0x00100000:0x00FFFFFF] (appClk domain)
-      appClk         : in  sl;
-      appRst         : in  sl;
-      appReadMaster  : out AxiLiteReadMasterType;
-      appReadSlave   : in  AxiLiteReadSlaveType;
-      appWriteMaster : out AxiLiteWriteMasterType;
-      appWriteSlave  : in  AxiLiteWriteSlaveType;
+      appClk          : in  sl;
+      appRst          : in  sl;
+      appReadMaster   : out AxiLiteReadMasterType;
+      appReadSlave    : in  AxiLiteReadSlaveType;
+      appWriteMaster  : out AxiLiteWriteMasterType;
+      appWriteSlave   : in  AxiLiteWriteSlaveType;
       -------------------
       --  Top Level Ports
       -------------------    
       -- System Ports
-      emcClk         : in  sl;
+      emcClk          : in  sl;
       -- Boot Memory Ports 
-      flashCsL       : out sl;
-      flashMosi      : out sl;
-      flashMiso      : in  sl;
-      flashHoldL     : out sl;
-      flashWp        : out sl;
+      flashCsL        : out sl;
+      flashMosi       : out sl;
+      flashMiso       : in  sl;
+      flashHoldL      : out sl;
+      flashWp         : out sl;
       -- PCIe Ports 
-      pciRstL        : in  sl;
-      pciRefClkP     : in  sl;
-      pciRefClkN     : in  sl;
-      pciRxP         : in  slv(7 downto 0);
-      pciRxN         : in  slv(7 downto 0);
-      pciTxP         : out slv(7 downto 0);
-      pciTxN         : out slv(7 downto 0));
+      pciRstL         : in  sl;
+      pciRefClkP      : in  sl;
+      pciRefClkN      : in  sl;
+      pciRxP          : in  slv(7 downto 0);
+      pciRxN          : in  slv(7 downto 0);
+      pciTxP          : out slv(7 downto 0);
+      pciTxN          : out slv(7 downto 0));
 end XilinxKcu105Core;
 
 architecture mapping of XilinxKcu105Core is
@@ -273,8 +275,8 @@ begin
          ROGUE_SIM_PORT_NUM_G => ROGUE_SIM_PORT_NUM_G,
          ROGUE_SIM_CH_COUNT_G => ROGUE_SIM_CH_COUNT_G,
          DMA_SIZE_G           => DMA_SIZE_G,
-         DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
-         DESC_ARB_G           => false)  -- Round robin to help with timing
+         DMA_BURST_BYTES_G    => DMA_BURST_BYTES_G,
+         DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G)
       port map (
          axiClk           => sysClock,
          axiRst           => sysReset,
@@ -290,6 +292,7 @@ begin
          axilWriteSlaves  => dmaCtrlWriteSlaves,
          -- DMA Interfaces
          dmaIrq           => dmaIrq,
+         dmaBuffGrpPause  => dmaBuffGrpPause,
          dmaObMasters     => dmaObMasters,
          dmaObSlaves      => dmaObSlaves,
          dmaIbMasters     => dmaIbMasters,

--- a/hardware/XilinxKcu116/rtl/XilinxKcu116Core.vhd
+++ b/hardware/XilinxKcu116/rtl/XilinxKcu116Core.vhd
@@ -6,11 +6,11 @@
 -- https://www.xilinx.com/products/boards-and-kits/kcu116.html
 -------------------------------------------------------------------------------
 -- This file is part of 'axi-pcie-core'.
--- It is subject to the license terms in the LICENSE.txt file found in the 
--- top-level directory of this distribution and at: 
---    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
--- No part of 'axi-pcie-core', including this file, 
--- may be copied, modified, propagated, or distributed except according to 
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'axi-pcie-core', including this file,
+-- may be copied, modified, propagated, or distributed except according to
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 
@@ -44,7 +44,7 @@ entity XilinxKcu116Core is
       DMA_BURST_BYTES_G    : positive range 256 to 4096  := 256;
       DMA_SIZE_G           : positive range 1 to 8       := 1);
    port (
-      ------------------------      
+      ------------------------
       --  Top Level Interfaces
       ------------------------
       -- DMA Interfaces  (dmaClk domain)
@@ -64,16 +64,16 @@ entity XilinxKcu116Core is
       appWriteSlave   : in  AxiLiteWriteSlaveType;
       -------------------
       --  Top Level Ports
-      -------------------    
+      -------------------
       -- System Ports
       emcClk          : in  sl;
-      -- Boot Memory Ports 
+      -- Boot Memory Ports
       flashCsL        : out sl;
       flashMosi       : out sl;
       flashMiso       : in  sl;
       flashHoldL      : out sl;
       flashWp         : out sl;
-      -- PCIe Ports 
+      -- PCIe Ports
       pciRstL         : in  sl;
       pciRefClkP      : in  sl;
       pciRefClkN      : in  sl;
@@ -139,7 +139,7 @@ begin
 
    ---------------
    -- AXI PCIe PHY
-   ---------------   
+   ---------------
    REAL_PCIE : if (not ROGUE_SIM_EN_G) generate
       U_AxiPciePhy : entity axi_pcie_core.XilinxKcu116PciePhyWrapper
          generic map (
@@ -162,7 +162,7 @@ begin
             phyWriteSlave  => phyWriteSlave,
             -- Interrupt Interface
             dmaIrq         => dmaIrq,
-            -- PCIe Ports 
+            -- PCIe Ports
             pciRstL        => pciRstL,
             pciRefClkP     => pciRefClkP,
             pciRefClkN     => pciRefClkN,
@@ -184,7 +184,7 @@ begin
 
    ---------------
    -- AXI PCIe REG
-   --------------- 
+   ---------------
    U_REG : entity axi_pcie_core.AxiPcieReg
       generic map (
          TPD_G                => TPD_G,
@@ -224,7 +224,7 @@ begin
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,
-         -- SPI Boot Memory Ports 
+         -- SPI Boot Memory Ports
          spiCsL              => bootCsL,
          spiSck              => bootSck,
          spiMosi             => bootMosi,
@@ -267,7 +267,7 @@ begin
 
    ---------------
    -- AXI PCIe DMA
-   ---------------   
+   ---------------
    U_AxiPcieDma : entity axi_pcie_core.AxiPcieDma
       generic map (
          TPD_G                => TPD_G,

--- a/hardware/XilinxKcu116/rtl/XilinxKcu116Core.vhd
+++ b/hardware/XilinxKcu116/rtl/XilinxKcu116Core.vhd
@@ -41,44 +41,46 @@ entity XilinxKcu116Core is
       BUILD_INFO_G         : BuildInfoType;
       DMA_AXIS_CONFIG_G    : AxiStreamConfigType;
       DRIVER_TYPE_ID_G     : slv(31 downto 0)            := x"00000000";
+      DMA_BURST_BYTES_G    : positive range 256 to 4096  := 256;
       DMA_SIZE_G           : positive range 1 to 8       := 1);
    port (
       ------------------------      
       --  Top Level Interfaces
       ------------------------
       -- DMA Interfaces  (dmaClk domain)
-      dmaClk         : out sl;
-      dmaRst         : out sl;
-      dmaObMasters   : out AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
-      dmaObSlaves    : in  AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
-      dmaIbMasters   : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
-      dmaIbSlaves    : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
+      dmaClk          : out sl;
+      dmaRst          : out sl;
+      dmaBuffGrpPause : out slv(7 downto 0);
+      dmaObMasters    : out AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
+      dmaObSlaves     : in  AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
+      dmaIbMasters    : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
+      dmaIbSlaves     : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
       -- Application AXI-Lite Interfaces [0x00100000:0x00FFFFFF] (appClk domain)
-      appClk         : in  sl;
-      appRst         : in  sl;
-      appReadMaster  : out AxiLiteReadMasterType;
-      appReadSlave   : in  AxiLiteReadSlaveType;
-      appWriteMaster : out AxiLiteWriteMasterType;
-      appWriteSlave  : in  AxiLiteWriteSlaveType;
+      appClk          : in  sl;
+      appRst          : in  sl;
+      appReadMaster   : out AxiLiteReadMasterType;
+      appReadSlave    : in  AxiLiteReadSlaveType;
+      appWriteMaster  : out AxiLiteWriteMasterType;
+      appWriteSlave   : in  AxiLiteWriteSlaveType;
       -------------------
       --  Top Level Ports
       -------------------    
       -- System Ports
-      emcClk         : in  sl;
+      emcClk          : in  sl;
       -- Boot Memory Ports 
-      flashCsL       : out sl;
-      flashMosi      : out sl;
-      flashMiso      : in  sl;
-      flashHoldL     : out sl;
-      flashWp        : out sl;
+      flashCsL        : out sl;
+      flashMosi       : out sl;
+      flashMiso       : in  sl;
+      flashHoldL      : out sl;
+      flashWp         : out sl;
       -- PCIe Ports 
-      pciRstL        : in  sl;
-      pciRefClkP     : in  sl;
-      pciRefClkN     : in  sl;
-      pciRxP         : in  slv(7 downto 0);
-      pciRxN         : in  slv(7 downto 0);
-      pciTxP         : out slv(7 downto 0);
-      pciTxN         : out slv(7 downto 0));
+      pciRstL         : in  sl;
+      pciRefClkP      : in  sl;
+      pciRefClkN      : in  sl;
+      pciRxP          : in  slv(7 downto 0);
+      pciRxN          : in  slv(7 downto 0);
+      pciTxP          : out slv(7 downto 0);
+      pciTxN          : out slv(7 downto 0));
 end XilinxKcu116Core;
 
 architecture mapping of XilinxKcu116Core is
@@ -273,10 +275,10 @@ begin
          ROGUE_SIM_PORT_NUM_G => ROGUE_SIM_PORT_NUM_G,
          ROGUE_SIM_CH_COUNT_G => ROGUE_SIM_CH_COUNT_G,
          DMA_SIZE_G           => DMA_SIZE_G,
+         DMA_BURST_BYTES_G    => DMA_BURST_BYTES_G,
          DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
          DESC_SYNTH_MODE_G    => "xpm",
-         DESC_MEMORY_TYPE_G   => "uram",
-         DESC_ARB_G           => false)  -- Round robin to help with timing
+         DESC_MEMORY_TYPE_G   => "uram")
       port map (
          axiClk           => sysClock,
          axiRst           => sysReset,
@@ -292,6 +294,7 @@ begin
          axilWriteSlaves  => dmaCtrlWriteSlaves,
          -- DMA Interfaces
          dmaIrq           => dmaIrq,
+         dmaBuffGrpPause  => dmaBuffGrpPause,
          dmaObMasters     => dmaObMasters,
          dmaObSlaves      => dmaObSlaves,
          dmaIbMasters     => dmaIbMasters,

--- a/hardware/XilinxKcu1500/pcie-extended/rtl/XilinxKcu1500PcieExtendedCore.vhd
+++ b/hardware/XilinxKcu1500/pcie-extended/rtl/XilinxKcu1500PcieExtendedCore.vhd
@@ -6,11 +6,11 @@
 -- https://www.xilinx.com/products/boards-and-kits/kcu1500.html
 -------------------------------------------------------------------------------
 -- This file is part of 'axi-pcie-core'.
--- It is subject to the license terms in the LICENSE.txt file found in the 
--- top-level directory of this distribution and at: 
---    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
--- No part of 'axi-pcie-core', including this file, 
--- may be copied, modified, propagated, or distributed except according to 
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'axi-pcie-core', including this file,
+-- may be copied, modified, propagated, or distributed except according to
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 
@@ -44,7 +44,7 @@ entity XilinxKcu1500PcieExtendedCore is
       DMA_BURST_BYTES_G    : positive range 256 to 4096  := 256;
       DMA_SIZE_G           : positive range 1 to 8       := 1);
    port (
-      ------------------------      
+      ------------------------
       --  Top Level Interfaces
       ------------------------
       -- DMA Interfaces  (dmaClk domain)
@@ -70,7 +70,7 @@ entity XilinxKcu1500PcieExtendedCore is
       -------------------
       --  Top Level Ports
       -------------------
-      -- Extended PCIe Ports 
+      -- Extended PCIe Ports
       pciRstL         : in  sl;
       pciExtRefClkP   : in  sl;
       pciExtRefClkN   : in  sl;
@@ -129,7 +129,7 @@ begin
 
    ---------------
    -- AXI PCIe PHY
-   ---------------   
+   ---------------
    REAL_PCIE : if (not ROGUE_SIM_EN_G) generate
       U_AxiPciePhy : entity axi_pcie_core.XilinxKcu1500ExtendedPciePhyWrapper
          generic map (
@@ -152,7 +152,7 @@ begin
             phyWriteSlave  => phyWriteSlave,
             -- Interrupt Interface
             dmaIrq         => dmaIrq,
-            -- PCIe Ports 
+            -- PCIe Ports
             pciRstL        => pciRstL,
             pciRefClkP     => pciExtRefClkP,
             pciRefClkN     => pciExtRefClkN,
@@ -189,7 +189,7 @@ begin
 
    ---------------
    -- AXI PCIe REG
-   --------------- 
+   ---------------
    U_REG : entity axi_pcie_core.AxiPcieReg
       generic map (
          TPD_G                => TPD_G,
@@ -236,7 +236,7 @@ begin
 
    ---------------
    -- AXI PCIe DMA
-   ---------------   
+   ---------------
    U_AxiPcieDma : entity axi_pcie_core.AxiPcieDma
       generic map (
          TPD_G                => TPD_G,

--- a/hardware/XilinxKcu1500/pcie-extended/rtl/XilinxKcu1500PcieExtendedCore.vhd
+++ b/hardware/XilinxKcu1500/pcie-extended/rtl/XilinxKcu1500PcieExtendedCore.vhd
@@ -41,41 +41,43 @@ entity XilinxKcu1500PcieExtendedCore is
       BUILD_INFO_G         : BuildInfoType;
       DMA_AXIS_CONFIG_G    : AxiStreamConfigType;
       DRIVER_TYPE_ID_G     : slv(31 downto 0)            := x"00000001";
+      DMA_BURST_BYTES_G    : positive range 256 to 4096  := 256;
       DMA_SIZE_G           : positive range 1 to 8       := 1);
    port (
       ------------------------      
       --  Top Level Interfaces
       ------------------------
       -- DMA Interfaces  (dmaClk domain)
-      dmaClk         : out sl;
-      dmaRst         : out sl;
-      dmaObMasters   : out AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
-      dmaObSlaves    : in  AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
-      dmaIbMasters   : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
-      dmaIbSlaves    : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
+      dmaClk          : out sl;
+      dmaRst          : out sl;
+      dmaBuffGrpPause : out slv(7 downto 0);
+      dmaObMasters    : out AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
+      dmaObSlaves     : in  AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
+      dmaIbMasters    : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
+      dmaIbSlaves     : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
       -- PIP Interface [0x00080000:0009FFFF] (dmaClk domain)
-      pipIbMaster    : out AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
-      pipIbSlave     : in  AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
-      pipObMaster    : in  AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
-      pipObSlave     : out AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
+      pipIbMaster     : out AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
+      pipIbSlave      : in  AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
+      pipObMaster     : in  AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
+      pipObSlave      : out AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
       -- Application AXI-Lite Interfaces [0x00100000:0x00FFFFFF] (appClk domain)
-      appClk         : in  sl                    := '0';
-      appRst         : in  sl                    := '1';
-      appReadMaster  : out AxiLiteReadMasterType;
-      appReadSlave   : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
-      appWriteMaster : out AxiLiteWriteMasterType;
-      appWriteSlave  : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
+      appClk          : in  sl                    := '0';
+      appRst          : in  sl                    := '1';
+      appReadMaster   : out AxiLiteReadMasterType;
+      appReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      appWriteMaster  : out AxiLiteWriteMasterType;
+      appWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------
       -- Extended PCIe Ports 
-      pciRstL        : in  sl;
-      pciExtRefClkP  : in  sl;
-      pciExtRefClkN  : in  sl;
-      pciExtRxP      : in  slv(7 downto 0);
-      pciExtRxN      : in  slv(7 downto 0);
-      pciExtTxP      : out slv(7 downto 0);
-      pciExtTxN      : out slv(7 downto 0));
+      pciRstL         : in  sl;
+      pciExtRefClkP   : in  sl;
+      pciExtRefClkN   : in  sl;
+      pciExtRxP       : in  slv(7 downto 0);
+      pciExtRxN       : in  slv(7 downto 0);
+      pciExtTxP       : out slv(7 downto 0);
+      pciExtTxN       : out slv(7 downto 0));
 end XilinxKcu1500PcieExtendedCore;
 
 architecture mapping of XilinxKcu1500PcieExtendedCore is
@@ -242,8 +244,8 @@ begin
          ROGUE_SIM_PORT_NUM_G => ROGUE_SIM_PORT_NUM_G,
          ROGUE_SIM_CH_COUNT_G => ROGUE_SIM_CH_COUNT_G,
          DMA_SIZE_G           => DMA_SIZE_G,
-         DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
-         DESC_ARB_G           => false)  -- Round robin to help with timing
+         DMA_BURST_BYTES_G    => DMA_BURST_BYTES_G,
+         DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G)
       port map (
          axiClk           => sysClock,
          axiRst           => sysReset,
@@ -261,6 +263,7 @@ begin
          axilWriteSlaves  => dmaCtrlWriteSlaves,
          -- DMA Interfaces
          dmaIrq           => dmaIrq,
+         dmaBuffGrpPause  => dmaBuffGrpPause,
          dmaObMasters     => dmaObMasters,
          dmaObSlaves      => dmaObSlaves,
          dmaIbMasters     => dmaIbMasters,

--- a/hardware/XilinxKcu1500/rtl/XilinxKcu1500Core.vhd
+++ b/hardware/XilinxKcu1500/rtl/XilinxKcu1500Core.vhd
@@ -41,67 +41,69 @@ entity XilinxKcu1500Core is
       BUILD_INFO_G         : BuildInfoType;
       DMA_AXIS_CONFIG_G    : AxiStreamConfigType;
       DRIVER_TYPE_ID_G     : slv(31 downto 0)            := x"00000000";
+      DMA_BURST_BYTES_G    : positive range 256 to 4096  := 256;
       DMA_SIZE_G           : positive range 1 to 8       := 1);
    port (
       ------------------------      
       --  Top Level Interfaces
       ------------------------
-      userClk156     : out sl;
+      userClk156      : out sl;
       -- DMA Interfaces  (dmaClk domain)
-      dmaClk         : out sl;
-      dmaRst         : out sl;
-      dmaObMasters   : out AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
-      dmaObSlaves    : in  AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
-      dmaIbMasters   : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
-      dmaIbSlaves    : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
+      dmaClk          : out sl;
+      dmaRst          : out sl;
+      dmaBuffGrpPause : out slv(7 downto 0);
+      dmaObMasters    : out AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
+      dmaObSlaves     : in  AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
+      dmaIbMasters    : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
+      dmaIbSlaves     : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
       -- PIP Interface [0x00080000:0009FFFF] (dmaClk domain)
-      pipIbMaster    : out AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
-      pipIbSlave     : in  AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
-      pipObMaster    : in  AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
-      pipObSlave     : out AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
+      pipIbMaster     : out AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
+      pipIbSlave      : in  AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
+      pipObMaster     : in  AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
+      pipObSlave      : out AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
       -- User General Purpose AXI4 Interfaces (dmaClk domain)
-      usrReadMaster  : in  AxiReadMasterType     := AXI_READ_MASTER_INIT_C;
-      usrReadSlave   : out AxiReadSlaveType      := AXI_READ_SLAVE_FORCE_C;
-      usrWriteMaster : in  AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
-      usrWriteSlave  : out AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
+      usrReadMaster   : in  AxiReadMasterType     := AXI_READ_MASTER_INIT_C;
+      usrReadSlave    : out AxiReadSlaveType      := AXI_READ_SLAVE_FORCE_C;
+      usrWriteMaster  : in  AxiWriteMasterType    := AXI_WRITE_MASTER_INIT_C;
+      usrWriteSlave   : out AxiWriteSlaveType     := AXI_WRITE_SLAVE_FORCE_C;
       -- Application AXI-Lite Interfaces [0x00100000:0x00FFFFFF] (appClk domain)
-      appClk         : in  sl                    := '0';
-      appRst         : in  sl                    := '1';
-      appReadMaster  : out AxiLiteReadMasterType;
-      appReadSlave   : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
-      appWriteMaster : out AxiLiteWriteMasterType;
-      appWriteSlave  : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
+      appClk          : in  sl                    := '0';
+      appRst          : in  sl                    := '1';
+      appReadMaster   : out AxiLiteReadMasterType;
+      appReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      appWriteMaster  : out AxiLiteWriteMasterType;
+      appWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------      
       -- System Ports
-      emcClk         : in  sl;
-      userClkP       : in  sl;
-      userClkN       : in  sl;
+      emcClk          : in  sl;
+      userClkP        : in  sl;
+      userClkN        : in  sl;
       -- QSFP[0] Ports
-      qsfp0RstL      : out sl;
-      qsfp0LpMode    : out sl;
-      qsfp0ModSelL   : out sl;
-      qsfp0ModPrsL   : in  sl                    := '0';
+      qsfp0RstL       : out sl;
+      qsfp0LpMode     : out sl;
+      qsfp0ModSelL    : out sl;
+      qsfp0ModPrsL    : in  sl                    := '0';
       -- QSFP[1] Ports
-      qsfp1RstL      : out sl;
-      qsfp1LpMode    : out sl;
-      qsfp1ModSelL   : out sl;
-      qsfp1ModPrsL   : in  sl                    := '0';
+      qsfp1RstL       : out sl;
+      qsfp1LpMode     : out sl;
+      qsfp1ModSelL    : out sl;
+      qsfp1ModPrsL    : in  sl                    := '0';
       -- Boot Memory Ports 
-      flashCsL       : out sl;
-      flashMosi      : out sl;
-      flashMiso      : in  sl;
-      flashHoldL     : out sl;
-      flashWp        : out sl;
+      flashCsL        : out sl;
+      flashMosi       : out sl;
+      flashMiso       : in  sl;
+      flashHoldL      : out sl;
+      flashWp         : out sl;
       -- PCIe Ports 
-      pciRstL        : in  sl;
-      pciRefClkP     : in  sl;
-      pciRefClkN     : in  sl;
-      pciRxP         : in  slv(7 downto 0);
-      pciRxN         : in  slv(7 downto 0);
-      pciTxP         : out slv(7 downto 0);
-      pciTxN         : out slv(7 downto 0));
+      pciRstL         : in  sl;
+      pciRefClkP      : in  sl;
+      pciRefClkN      : in  sl;
+      pciRxP          : in  slv(7 downto 0);
+      pciRxN          : in  slv(7 downto 0);
+      pciTxP          : out slv(7 downto 0);
+      pciTxN          : out slv(7 downto 0));
 end XilinxKcu1500Core;
 
 architecture mapping of XilinxKcu1500Core is
@@ -332,8 +334,8 @@ begin
          ROGUE_SIM_PORT_NUM_G => ROGUE_SIM_PORT_NUM_G,
          ROGUE_SIM_CH_COUNT_G => ROGUE_SIM_CH_COUNT_G,
          DMA_SIZE_G           => DMA_SIZE_G,
-         DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
-         DESC_ARB_G           => false)  -- Round robin to help with timing
+         DMA_BURST_BYTES_G    => DMA_BURST_BYTES_G,
+         DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G)
       port map (
          axiClk           => sysClock,
          axiRst           => sysReset,
@@ -357,6 +359,7 @@ begin
          axilWriteSlaves  => dmaCtrlWriteSlaves,
          -- DMA Interfaces
          dmaIrq           => dmaIrq,
+         dmaBuffGrpPause  => dmaBuffGrpPause,
          dmaObMasters     => dmaObMasters,
          dmaObSlaves      => dmaObSlaves,
          dmaIbMasters     => dmaIbMasters,

--- a/hardware/XilinxKcu1500/rtl/XilinxKcu1500Core.vhd
+++ b/hardware/XilinxKcu1500/rtl/XilinxKcu1500Core.vhd
@@ -6,11 +6,11 @@
 -- https://www.xilinx.com/products/boards-and-kits/kcu1500.html
 -------------------------------------------------------------------------------
 -- This file is part of 'axi-pcie-core'.
--- It is subject to the license terms in the LICENSE.txt file found in the 
--- top-level directory of this distribution and at: 
---    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
--- No part of 'axi-pcie-core', including this file, 
--- may be copied, modified, propagated, or distributed except according to 
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'axi-pcie-core', including this file,
+-- may be copied, modified, propagated, or distributed except according to
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 
@@ -44,7 +44,7 @@ entity XilinxKcu1500Core is
       DMA_BURST_BYTES_G    : positive range 256 to 4096  := 256;
       DMA_SIZE_G           : positive range 1 to 8       := 1);
    port (
-      ------------------------      
+      ------------------------
       --  Top Level Interfaces
       ------------------------
       userClk156      : out sl;
@@ -75,7 +75,7 @@ entity XilinxKcu1500Core is
       appWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
-      -------------------      
+      -------------------
       -- System Ports
       emcClk          : in  sl;
       userClkP        : in  sl;
@@ -90,13 +90,13 @@ entity XilinxKcu1500Core is
       qsfp1LpMode     : out sl;
       qsfp1ModSelL    : out sl;
       qsfp1ModPrsL    : in  sl                    := '0';
-      -- Boot Memory Ports 
+      -- Boot Memory Ports
       flashCsL        : out sl;
       flashMosi       : out sl;
       flashMiso       : in  sl;
       flashHoldL      : out sl;
       flashWp         : out sl;
-      -- PCIe Ports 
+      -- PCIe Ports
       pciRstL         : in  sl;
       pciRefClkP      : in  sl;
       pciRefClkN      : in  sl;
@@ -180,7 +180,7 @@ begin
 
    ---------------
    -- AXI PCIe PHY
-   ---------------   
+   ---------------
    REAL_PCIE : if (not ROGUE_SIM_EN_G) generate
 
       U_AxiPciePhy : entity axi_pcie_core.XilinxKcu1500PciePhyWrapper
@@ -204,7 +204,7 @@ begin
             phyWriteSlave  => phyWriteSlave,
             -- Interrupt Interface
             dmaIrq         => dmaIrq,
-            -- PCIe Ports 
+            -- PCIe Ports
             pciRstL        => pciRstL,
             pciRefClkP     => pciRefClkP,
             pciRefClkN     => pciRefClkN,
@@ -241,7 +241,7 @@ begin
 
    ---------------
    -- AXI PCIe REG
-   --------------- 
+   ---------------
    U_REG : entity axi_pcie_core.AxiPcieReg
       generic map (
          TPD_G                => TPD_G,
@@ -283,7 +283,7 @@ begin
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,
-         -- SPI Boot Memory Ports 
+         -- SPI Boot Memory Ports
          spiCsL              => bootCsL,
          spiSck              => bootSck,
          spiMosi             => bootMosi,
@@ -326,7 +326,7 @@ begin
 
    ---------------
    -- AXI PCIe DMA
-   ---------------   
+   ---------------
    U_AxiPcieDma : entity axi_pcie_core.AxiPcieDma
       generic map (
          TPD_G                => TPD_G,

--- a/shared/rtl/AxiPcieDma.vhd
+++ b/shared/rtl/AxiPcieDma.vhd
@@ -5,11 +5,11 @@
 -- Description: Wrapper for AXIS DMA Engine
 -------------------------------------------------------------------------------
 -- This file is part of 'axi-pcie-core'.
--- It is subject to the license terms in the LICENSE.txt file found in the 
--- top-level directory of this distribution and at: 
---    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
--- No part of 'axi-pcie-core', including this file, 
--- may be copied, modified, propagated, or distributed except according to 
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'axi-pcie-core', including this file,
+-- may be copied, modified, propagated, or distributed except according to
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 
@@ -86,7 +86,7 @@ architecture mapping of AxiPcieDma is
       TUSER_BITS_C  => 4,
       TUSER_MODE_C  => TUSER_FIRST_LAST_C);
 
-   -- DMA AXI Configuration   
+   -- DMA AXI Configuration
    constant DMA_AXI_CONFIG_C : AxiConfigType := (
       ADDR_WIDTH_C => AXI_PCIE_CONFIG_C.ADDR_WIDTH_C,
       DATA_BYTES_C => INT_DMA_AXIS_CONFIG_C.TDATA_BYTES_C,  -- Matches the AXIS stream
@@ -172,7 +172,7 @@ begin
             axilWriteSlave  => axilWriteSlaves(0),
             interrupt       => dmaIrq,
             buffGrpPause    => dmaBuffGrpPause,
-            -- AXI Stream Interface 
+            -- AXI Stream Interface
             sAxisMasters    => sAxisMasters,
             sAxisSlaves     => sAxisSlaves,
             mAxisMasters    => mAxisMasters,
@@ -354,8 +354,8 @@ begin
          -- DMA[Lane=1][TDEST=0] maps to TCP ports ROGUE_SIM_PORT_NUM_G+514
          -- DMA[Lane=1][TDEST=1] maps to TCP ports ROGUE_SIM_PORT_NUM_G+516
          -- .....
-         -- .....         
-         -------------------------------------------------------         
+         -- .....
+         -------------------------------------------------------
 
          U_DMA_LANE : entity surf.RogueTcpStreamWrap
             generic map (

--- a/shared/rtl/AxiPcieDma.vhd
+++ b/shared/rtl/AxiPcieDma.vhd
@@ -81,7 +81,7 @@ architecture mapping of AxiPcieDma is
       TSTRB_EN_C    => false,
       TDATA_BYTES_C => DMA_AXIS_CONFIG_G.TDATA_BYTES_C,
       TDEST_BITS_C  => 8,
-      TID_BITS_C    => 0,
+      TID_BITS_C    => 3,
       TKEEP_MODE_C  => TKEEP_COUNT_C,  -- AXI DMA V2 uses TKEEP_COUNT_C to help meet timing
       TUSER_BITS_C  => 4,
       TUSER_MODE_C  => TUSER_FIRST_LAST_C);

--- a/shared/rtl/AxiPcieDma.vhd
+++ b/shared/rtl/AxiPcieDma.vhd
@@ -43,7 +43,7 @@ entity AxiPcieDma is
       PIPE_STAGES_G        : natural range 0 to 1         := 1;
       DESC_SYNTH_MODE_G    : string                       := "inferred";
       DESC_MEMORY_TYPE_G   : string                       := "block";
-      DESC_ARB_G           : boolean                      := true);
+      DESC_ARB_G           : boolean                      := false);  -- false = Round robin to help with timing
    port (
       -- Clock and Reset
       axiClk           : in  sl;
@@ -68,6 +68,7 @@ entity AxiPcieDma is
       axilWriteSlaves  : out AxiLiteWriteSlaveArray(2 downto 0) := (others => AXI_LITE_WRITE_SLAVE_EMPTY_OK_C);
       -- DMA Interfaces (axiClk domain)
       dmaIrq           : out sl                                 := '0';
+      dmaBuffGrpPause  : out slv(7 downto 0)                    := (others => '0');
       dmaObMasters     : out AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
       dmaObSlaves      : in  AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
       dmaIbMasters     : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
@@ -170,6 +171,7 @@ begin
             axilWriteMaster => axilWriteMasters(0),
             axilWriteSlave  => axilWriteSlaves(0),
             interrupt       => dmaIrq,
+            buffGrpPause    => dmaBuffGrpPause,
             -- AXI Stream Interface 
             sAxisMasters    => sAxisMasters,
             sAxisSlaves     => sAxisSlaves,

--- a/shared/ruckus.tcl
+++ b/shared/ruckus.tcl
@@ -3,8 +3,8 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 
 # Check for submodule tagging
 if { [info exists ::env(OVERRIDE_SUBMODULE_LOCKS)] != 1 || $::env(OVERRIDE_SUBMODULE_LOCKS) == 0 } {
-   if { [SubmoduleCheck {ruckus} {2.1.2} ] < 0 } {exit -1}
-   if { [SubmoduleCheck {surf}   {2.0.6} ] < 0 } {exit -1}
+   if { [SubmoduleCheck {ruckus} {2.6.0} ] < 0 } {exit -1}
+   if { [SubmoduleCheck {surf}   {2.7.0} ] < 0 } {exit -1}
 } else {
    puts "\n\n*********************************************************"
    puts "OVERRIDE_SUBMODULE_LOCKS != 0"


### PR DESCRIPTION
The goal of this PR is to allow a limit on the number of outstanding DMA buffers any single destination can be using. This will allow the client to set a max buffer count after opening a channel on the driver. The end result is a flow control signal which extends outside of the dma engine to the mux point for a set of streams.

In order to accomplish this we need to communicate this per dest pause to the mux stage. Here I propose adding a destPause vector to the AxiStreamCtrl record and using this record in the AxiStreamMux device.
