### PR TITLE
Release Candidate v3.6.0

### DIFF
--- a/hardware/SlacPgpCardG4/xdc/SlacPgpCardGen4App.xdc
+++ b/hardware/SlacPgpCardG4/xdc/SlacPgpCardGen4App.xdc
@@ -12,12 +12,6 @@
 # System #
 ##########
 
-set_property -dict { PACKAGE_PIN AJ8  IOSTANDARD LVCMOS33 } [get_ports { qsfpScl[0] }]
-set_property -dict { PACKAGE_PIN AN8  IOSTANDARD LVCMOS33 } [get_ports { qsfpSda[0] }]
-
-set_property -dict { PACKAGE_PIN AP8  IOSTANDARD LVCMOS33 } [get_ports { qsfpScl[1] }]
-set_property -dict { PACKAGE_PIN AK10 IOSTANDARD LVCMOS33 } [get_ports { qsfpSda[1] }]
-
 set_property -dict { PACKAGE_PIN AL9  IOSTANDARD LVCMOS33 } [get_ports { ledRedL[0]   }]
 set_property -dict { PACKAGE_PIN AN9  IOSTANDARD LVCMOS33 } [get_ports { ledBlueL[0]  }]
 set_property -dict { PACKAGE_PIN AP9  IOSTANDARD LVCMOS33 } [get_ports { ledGreenL[0] }]
@@ -42,22 +36,9 @@ set_property -dict { PACKAGE_PIN AJ10 IOSTANDARD LVCMOS33 } [get_ports { ledRedL
 set_property -dict { PACKAGE_PIN AF10 IOSTANDARD LVCMOS33 } [get_ports { ledBlueL[5]  }]
 set_property -dict { PACKAGE_PIN AG10 IOSTANDARD LVCMOS33 } [get_ports { ledGreenL[5] }]
 
-set_property -dict { PACKAGE_PIN AP11 IOSTANDARD LVCMOS33 } [get_ports { pwrScl }]
-set_property -dict { PACKAGE_PIN AP10 IOSTANDARD LVCMOS33 } [get_ports { pwrSda }]
-
 #######
 # SFP #
 #######
-
-set_property -dict { PACKAGE_PIN AK8  IOSTANDARD LVCMOS33 } [get_ports { sfpScl }]
-set_property -dict { PACKAGE_PIN AL8  IOSTANDARD LVCMOS33 } [get_ports { sfpSda }]
-
-set_property -dict { PACKAGE_PIN AG11 IOSTANDARD LVCMOS33 } [get_ports { sfpRs[1]   }]; # SFP_0
-set_property -dict { PACKAGE_PIN AH11 IOSTANDARD LVCMOS33 } [get_ports { sfpRxLos   }]; # SFP_1
-set_property -dict { PACKAGE_PIN AJ11 IOSTANDARD LVCMOS33 } [get_ports { sfpRs[0]   }]; # SFP_2
-set_property -dict { PACKAGE_PIN AG12 IOSTANDARD LVCMOS33 } [get_ports { sfpAbs     }]; # SFP_3
-set_property -dict { PACKAGE_PIN AH12 IOSTANDARD LVCMOS33 } [get_ports { sfpTxDis   }]; # SFP_4
-set_property -dict { PACKAGE_PIN AD11 IOSTANDARD LVCMOS33 } [get_ports { sfpTxFault }]; # SFP_5
 
 set_property PACKAGE_PIN K6 [get_ports { sfpRefClkP[0] }] ;# 238 MHz
 set_property PACKAGE_PIN K5 [get_ports { sfpRefClkN[0] }] ;# 238 MHz

--- a/hardware/SlacPgpCardG4/xdc/SlacPgpCardGen4Core.xdc
+++ b/hardware/SlacPgpCardG4/xdc/SlacPgpCardGen4Core.xdc
@@ -8,6 +8,41 @@
 ## the terms contained in the LICENSE.txt file.
 ##############################################################################
 
+####################
+# I2C: Constraints #
+####################
+
+set_property -dict { PACKAGE_PIN AP11 IOSTANDARD LVCMOS33 } [get_ports { pwrScl }]
+set_property -dict { PACKAGE_PIN AP10 IOSTANDARD LVCMOS33 } [get_ports { pwrSda }]
+
+set_property -dict { PACKAGE_PIN AJ8  IOSTANDARD LVCMOS33 } [get_ports { qsfpScl[0] }]
+set_property -dict { PACKAGE_PIN AN8  IOSTANDARD LVCMOS33 } [get_ports { qsfpSda[0] }]
+
+set_property -dict { PACKAGE_PIN AP8  IOSTANDARD LVCMOS33 } [get_ports { qsfpScl[1] }]
+set_property -dict { PACKAGE_PIN AK10 IOSTANDARD LVCMOS33 } [get_ports { qsfpSda[1] }]
+
+set_property -dict { PACKAGE_PIN AK8  IOSTANDARD LVCMOS33 } [get_ports { sfpScl }]
+set_property -dict { PACKAGE_PIN AL8  IOSTANDARD LVCMOS33 } [get_ports { sfpSda }]
+
+set_property -dict { PACKAGE_PIN AG11 IOSTANDARD LVCMOS33 } [get_ports { sfpRs[1]   }]; # SFP_0
+set_property -dict { PACKAGE_PIN AH11 IOSTANDARD LVCMOS33 } [get_ports { sfpRxLos   }]; # SFP_1
+set_property -dict { PACKAGE_PIN AJ11 IOSTANDARD LVCMOS33 } [get_ports { sfpRs[0]   }]; # SFP_2
+set_property -dict { PACKAGE_PIN AG12 IOSTANDARD LVCMOS33 } [get_ports { sfpAbs     }]; # SFP_3
+set_property -dict { PACKAGE_PIN AH12 IOSTANDARD LVCMOS33 } [get_ports { sfpTxDis   }]; # SFP_4
+set_property -dict { PACKAGE_PIN AD11 IOSTANDARD LVCMOS33 } [get_ports { sfpTxFault }]; # SFP_5
+
+set_property -dict { PACKAGE_PIN AE11 IOSTANDARD LVCMOS33 } [get_ports { qsfpRstL[0]    }]; # QSFP0_0
+set_property -dict { PACKAGE_PIN AE12 IOSTANDARD LVCMOS33 } [get_ports { qsfpModSelL[0] }]; # QSFP0_1
+set_property -dict { PACKAGE_PIN AF12 IOSTANDARD LVCMOS33 } [get_ports { qsfpIntL[0]    }]; # QSFP0_2
+set_property -dict { PACKAGE_PIN AH13 IOSTANDARD LVCMOS33 } [get_ports { qsfpModPrsL[0] }]; # QSFP0_3
+set_property -dict { PACKAGE_PIN AJ13 IOSTANDARD LVCMOS33 } [get_ports { qsfpLpMode[0]  }]; # QSFP0_4
+
+set_property -dict { PACKAGE_PIN AE13 IOSTANDARD LVCMOS33 } [get_ports { qsfpRstL[1]    }]; # QSFP1_0
+set_property -dict { PACKAGE_PIN AF13 IOSTANDARD LVCMOS33 } [get_ports { qsfpModSelL[1] }]; # QSFP1_1
+set_property -dict { PACKAGE_PIN AK13 IOSTANDARD LVCMOS33 } [get_ports { qsfpIntL[1]    }]; # QSFP1_2
+set_property -dict { PACKAGE_PIN AL13 IOSTANDARD LVCMOS33 } [get_ports { qsfpModPrsL[1] }]; # QSFP1_3
+set_property -dict { PACKAGE_PIN AK12 IOSTANDARD LVCMOS33 } [get_ports { qsfpLpMode[1]  }]; # QSFP1_4
+
 ######################
 # FLASH: Constraints #
 ######################

--- a/hardware/XilinxAc701/ruckus.tcl
+++ b/hardware/XilinxAc701/ruckus.tcl
@@ -13,7 +13,7 @@ if { $::env(PRJ_PART) != "XC7A200TFBG676-2" } {
 if { [VersionCheck 2018.2] < 0 } {exit -1}
 
 # Set the board part
-set_property board_part xilinx.com:ac701:part0:1.3 [current_project]
+set_property board_part xilinx.com:ac701:part0:1.4 [current_project]
 
 #######################################################################################
 # 7-Series PCIe IP core appear to not support 40-bit address (even with 64-bit enabled)

--- a/hardware/XilinxKc705/ruckus.tcl
+++ b/hardware/XilinxKc705/ruckus.tcl
@@ -13,7 +13,7 @@ if { $::env(PRJ_PART) != "XC7K325TFFG900-2" } {
 if { [VersionCheck 2018.2] < 0 } {exit -1}
 
 # Set the board part
-set_property board_part xilinx.com:kc705:part0:1.5 [current_project]
+set_property board_part xilinx.com:kc705:part0:1.6 [current_project]
 
 #######################################################################################
 # 7-Series PCIe IP core appear to not support 40-bit address (even with 64-bit enabled)

--- a/hardware/XilinxKcu105/ruckus.tcl
+++ b/hardware/XilinxKcu105/ruckus.tcl
@@ -13,7 +13,7 @@ if { $::env(PRJ_PART) != "XCKU040-FFVA1156-2-E" } {
 }
 
 # Set the board part
-set_property board_part xilinx.com:kcu105:part0:1.3 [current_project]
+set_property board_part xilinx.com:kcu105:part0:1.6 [current_project]
 
 # Load local Source Code and Constraints
 loadSource -lib axi_pcie_core      -dir  "$::DIR_PATH/rtl"

--- a/hardware/XilinxKcu116/ruckus.tcl
+++ b/hardware/XilinxKcu116/ruckus.tcl
@@ -13,7 +13,7 @@ if { $::env(PRJ_PART) != "XCKU5P-FFVB676-2-E" } {
 }
 
 # Set the board part
-set_property board_part xilinx.com:kcu116:part0:1.2 [current_project]
+set_property board_part xilinx.com:kcu116:part0:1.5 [current_project]
 
 # Load local Source Code and Constraints
 loadSource -lib axi_pcie_core      -dir  "$::DIR_PATH/rtl"

--- a/python/axipcie/_AxiPcieCore.py
+++ b/python/axipcie/_AxiPcieCore.py
@@ -11,7 +11,10 @@
 import pyrogue              as pr
 import surf.axi             as axi
 import surf.devices.micron  as micron
+import surf.devices.nxp     as nxp
 import surf.xilinx          as xil
+
+import surf.devices.transceivers as xceiver
 
 import axipcie
 import click
@@ -23,6 +26,7 @@ class AxiPcieCore(pr.Device):
                  useBpi      = False,
                  useSpi      = False,
                  numDmaLanes = 1,
+                 boardType   = None,
                  **kwargs):
         super().__init__(description=description, **kwargs)
 
@@ -71,10 +75,42 @@ class AxiPcieCore(pr.Device):
         # DMA AXI Stream Outbound Monitor
         self.add(axi.AxiStreamMonAxiL(
             name        = 'DmaObAxisMon',
-            offset      = 0x70000,
+            offset      = 0x68000,
             numberLanes = self.numDmaLanes,
             expand      = False,
         ))
+
+        # I2C access is slow.  So using a AXI-Lite proxy to prevent holding up CPU during a BAR0 memory map transaction
+        self.add(axi.AxiLiteMasterProxy(
+            name   = 'AxilBridge',
+            offset = 0x70000,
+        ))
+
+        # Check for the SLAC GEN4 PGP Card
+        if boardType is 'SlacPgpCardG4':
+
+            for i in range(2):
+                self.add(xceiver.Qsfp(
+                    name    = f'Qsfp[{i}]',
+                    offset  = i*0x1000+0x70000,
+                    memBase = self.AxilBridge.proxy,
+                    enabled = False, # enabled=False because I2C are slow transactions and might "log jam" register transaction pipeline
+                ))
+
+            self.add(xceiver.Sfp(
+                name        = 'Sfp',
+                offset      = 0x72000,
+                memBase     = self.AxilBridge.proxy,
+                enabled     = False, # enabled=False because I2C are slow transactions and might "log jam" register transaction pipeline
+            ))
+
+            self.add(nxp.Sa56004x(
+                name        = 'BoardTemp',
+                description = 'This device monitors the board temperature and FPGA junction temperature',
+                offset      = 0x73000,
+                memBase     = self.AxilBridge.proxy,
+                enabled     = False, # enabled=False because I2C are slow transactions and might "log jam" register transaction pipeline
+            ))
 
     def _start(self):
         super()._start()

--- a/python/axipcie/_AxiPcieCore.py
+++ b/python/axipcie/_AxiPcieCore.py
@@ -87,7 +87,7 @@ class AxiPcieCore(pr.Device):
         ))
 
         # Check for the SLAC GEN4 PGP Card
-        if boardType is 'SlacPgpCardG4':
+        if boardType == 'SlacPgpCardG4':
 
             for i in range(2):
                 self.add(xceiver.Qsfp(

--- a/shared/ruckus.tcl
+++ b/shared/ruckus.tcl
@@ -4,7 +4,7 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 # Check for submodule tagging
 if { [info exists ::env(OVERRIDE_SUBMODULE_LOCKS)] != 1 || $::env(OVERRIDE_SUBMODULE_LOCKS) == 0 } {
    if { [SubmoduleCheck {ruckus} {2.6.0} ] < 0 } {exit -1}
-   if { [SubmoduleCheck {surf}   {2.7.0} ] < 0 } {exit -1}
+   if { [SubmoduleCheck {surf}   {2.20.0} ] < 0 } {exit -1}
 } else {
    puts "\n\n*********************************************************"
    puts "OVERRIDE_SUBMODULE_LOCKS != 0"


### PR DESCRIPTION
### Description
- Updating dev board revision numbers (required for Vivado 2021 or later)
  - ac701: v1.3 to v1.4
  - kc705: v1.5 to v1.6
  - kcu105: v1.3 to v1.6
  - kcu116: v1.2 to v1.5
- adding I2C AXI-Lite interface via a surf.AxiLiteMasterProxy
- adding I2C registers to hardware/SlacPgpCardG4