### PR TITLE
adding PCIE_HW_TYPE_G

### DIFF
--- a/hardware/AlphaDataKu3/rtl/AlphaDataKu3Core.vhd
+++ b/hardware/AlphaDataKu3/rtl/AlphaDataKu3Core.vhd
@@ -200,6 +200,7 @@ begin
          XIL_DEVICE_G         => "ULTRASCALE",
          BOOT_PROM_G          => "NOT_SUPPORTED",
          DRIVER_TYPE_ID_G     => DRIVER_TYPE_ID_G,
+         PCIE_HW_TYPE_G       => HW_TYPE_ALPHADATA_KU3_C,
          DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
          DMA_SIZE_G           => DMA_SIZE_G)
       port map (

--- a/hardware/BittWareXupVv8/core/BittWareXupVv8Core.vhd
+++ b/hardware/BittWareXupVv8/core/BittWareXupVv8Core.vhd
@@ -226,6 +226,7 @@ begin
          XIL_DEVICE_G         => "ULTRASCALE",
          BOOT_PROM_G          => "SPIx4",
          DRIVER_TYPE_ID_G     => DRIVER_TYPE_ID_G,
+         PCIE_HW_TYPE_G       => HW_TYPE_BITTWARE_XUP_VV8_C,
          DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
          DMA_SIZE_G           => DMA_SIZE_G)
       port map (

--- a/hardware/SlacPgpCardG3/rtl/AxiPciePgpCardG3Core.vhd
+++ b/hardware/SlacPgpCardG3/rtl/AxiPciePgpCardG3Core.vhd
@@ -188,6 +188,7 @@ begin
          XIL_DEVICE_G         => "7SERIES",
          BOOT_PROM_G          => "BPI",
          DRIVER_TYPE_ID_G     => DRIVER_TYPE_ID_G,
+         PCIE_HW_TYPE_G       => HW_TYPE_SLAC_PGP_GEN3_C,
          DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_C,
          DMA_SIZE_G           => DMA_SIZE_G)
       port map (

--- a/hardware/SlacPgpCardG4/rtl/SlacPgpCardG4Core.vhd
+++ b/hardware/SlacPgpCardG4/rtl/SlacPgpCardG4Core.vhd
@@ -348,6 +348,7 @@ begin
          XIL_DEVICE_G         => "ULTRASCALE",
          BOOT_PROM_G          => "SPIx8",
          DRIVER_TYPE_ID_G     => DRIVER_TYPE_ID_G,
+         PCIE_HW_TYPE_G       => HW_TYPE_SLAC_PGP_GEN4_C,
          DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
          DMA_SIZE_G           => DMA_SIZE_G)
       port map (

--- a/hardware/XilinxAc701/rtl/XilinxAc701Core.vhd
+++ b/hardware/XilinxAc701/rtl/XilinxAc701Core.vhd
@@ -189,6 +189,7 @@ begin
          XIL_DEVICE_G         => "7SERIES",
          BOOT_PROM_G          => "SPIx4",
          DRIVER_TYPE_ID_G     => DRIVER_TYPE_ID_G,
+         PCIE_HW_TYPE_G       => HW_TYPE_XILINX_AC701_C,
          DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_C,
          DMA_SIZE_G           => DMA_SIZE_G)
       port map (

--- a/hardware/XilinxAlveoU200/core/XilinxAlveoU200Core.vhd
+++ b/hardware/XilinxAlveoU200/core/XilinxAlveoU200Core.vhd
@@ -234,6 +234,7 @@ begin
          XIL_DEVICE_G         => "ULTRASCALE",
          BOOT_PROM_G          => "SPIx4",
          DRIVER_TYPE_ID_G     => DRIVER_TYPE_ID_G,
+         PCIE_HW_TYPE_G       => HW_TYPE_XILINX_U200_C,
          DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
          DMA_SIZE_G           => DMA_SIZE_G)
       port map (

--- a/hardware/XilinxAlveoU250/core/XilinxAlveoU250Core.vhd
+++ b/hardware/XilinxAlveoU250/core/XilinxAlveoU250Core.vhd
@@ -234,6 +234,7 @@ begin
          XIL_DEVICE_G         => "ULTRASCALE",
          BOOT_PROM_G          => "SPIx4",
          DRIVER_TYPE_ID_G     => DRIVER_TYPE_ID_G,
+         PCIE_HW_TYPE_G       => HW_TYPE_XILINX_U250_C,
          DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
          DMA_SIZE_G           => DMA_SIZE_G)
       port map (

--- a/hardware/XilinxAlveoU280/pcie-3x16/rtl/XilinxAlveoU280Core.vhd
+++ b/hardware/XilinxAlveoU280/pcie-3x16/rtl/XilinxAlveoU280Core.vhd
@@ -233,6 +233,7 @@ begin
          XIL_DEVICE_G         => "ULTRASCALE",
          BOOT_PROM_G          => "SPIx4",
          DRIVER_TYPE_ID_G     => DRIVER_TYPE_ID_G,
+         PCIE_HW_TYPE_G       => HW_TYPE_XILINX_U280_C,
          DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
          DMA_SIZE_G           => DMA_SIZE_G)
       port map (

--- a/hardware/XilinxAlveoU50/pcie-3x16/rtl/XilinxAlveoU50Core.vhd
+++ b/hardware/XilinxAlveoU50/pcie-3x16/rtl/XilinxAlveoU50Core.vhd
@@ -221,6 +221,7 @@ begin
          XIL_DEVICE_G         => "ULTRASCALE",
          BOOT_PROM_G          => "SPIx4",
          DRIVER_TYPE_ID_G     => DRIVER_TYPE_ID_G,
+         PCIE_HW_TYPE_G       => HW_TYPE_XILINX_U50_C,
          DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
          DMA_SIZE_G           => DMA_SIZE_G)
       port map (

--- a/hardware/XilinxKc705/rtl/XilinxKc705Core.vhd
+++ b/hardware/XilinxKc705/rtl/XilinxKc705Core.vhd
@@ -194,6 +194,7 @@ begin
          XIL_DEVICE_G         => "7SERIES",
          BOOT_PROM_G          => "SPIx4",
          DRIVER_TYPE_ID_G     => DRIVER_TYPE_ID_G,
+         PCIE_HW_TYPE_G       => HW_TYPE_XILINX_KC705_C,
          DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_C,
          DMA_SIZE_G           => DMA_SIZE_G)
       port map (

--- a/hardware/XilinxKcu105/rtl/XilinxKcu105Core.vhd
+++ b/hardware/XilinxKcu105/rtl/XilinxKcu105Core.vhd
@@ -194,6 +194,7 @@ begin
          XIL_DEVICE_G         => "ULTRASCALE",
          BOOT_PROM_G          => "SPIx8",
          DRIVER_TYPE_ID_G     => DRIVER_TYPE_ID_G,
+         PCIE_HW_TYPE_G       => HW_TYPE_XILINX_KCU105_C,
          DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
          DMA_SIZE_G           => DMA_SIZE_G)
       port map (

--- a/hardware/XilinxKcu116/rtl/XilinxKcu116Core.vhd
+++ b/hardware/XilinxKcu116/rtl/XilinxKcu116Core.vhd
@@ -194,6 +194,7 @@ begin
          XIL_DEVICE_G         => "ULTRASCALE",
          BOOT_PROM_G          => "SPIx8",
          DRIVER_TYPE_ID_G     => DRIVER_TYPE_ID_G,
+         PCIE_HW_TYPE_G       => HW_TYPE_XILINX_KCU116_C,
          DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
          DMA_SIZE_G           => DMA_SIZE_G)
       port map (

--- a/hardware/XilinxKcu1500/rtl/XilinxKcu1500Core.vhd
+++ b/hardware/XilinxKcu1500/rtl/XilinxKcu1500Core.vhd
@@ -394,6 +394,7 @@ begin
          XIL_DEVICE_G         => "ULTRASCALE",
          BOOT_PROM_G          => "SPIx8",
          DRIVER_TYPE_ID_G     => DRIVER_TYPE_ID_G,
+         PCIE_HW_TYPE_G       => HW_TYPE_XILINX_KCU1500_C,
          DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
          DMA_SIZE_G           => DMA_SIZE_G)
       port map (

--- a/hardware/XilinxVcu128/pcie-3x16/rtl/XilinxVcu128Core.vhd
+++ b/hardware/XilinxVcu128/pcie-3x16/rtl/XilinxVcu128Core.vhd
@@ -229,6 +229,7 @@ begin
          XIL_DEVICE_G         => "ULTRASCALE",
          BOOT_PROM_G          => "SPIx4",
          DRIVER_TYPE_ID_G     => DRIVER_TYPE_ID_G,
+         PCIE_HW_TYPE_G       => HW_TYPE_XILINX_VCU128_C,
          DMA_AXIS_CONFIG_G    => DMA_AXIS_CONFIG_G,
          DMA_SIZE_G           => DMA_SIZE_G)
       port map (

--- a/python/axipcie/_PcieAxiVersion.py
+++ b/python/axipcie/_PcieAxiVersion.py
@@ -202,3 +202,28 @@ class PcieAxiVersion(axi.AxiVersion):
             mode         = "RO",
             pollInterval = 1
         ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'PCIE_HW_TYPE_G',
+            offset       = 0x400+(4*9),
+            bitSize      = 32,
+            bitOffset    = 0,
+            mode         = 'RO',
+            enum        = {
+                0x00_00_00_00: 'Undefined',
+                0x00_00_00_01: 'AlphaDataKu3',
+                0x00_00_00_02: 'BittWareXupVv8',
+                0x00_00_00_03: 'SlacPgpCardG3',
+                0x00_00_00_04: 'SlacPgpCardG4',
+                0x00_00_00_05: 'XilinxAc701',
+                0x00_00_00_06: 'XilinxAlveoU50',
+                0x00_00_00_07: 'XilinxAlveoU200',
+                0x00_00_00_08: 'XilinxAlveoU250',
+                0x00_00_00_09: 'XilinxAlveoU280',
+                0x00_00_00_0A: 'XilinxKc705',
+                0x00_00_00_0B: 'XilinxKcu105',
+                0x00_00_00_0C: 'XilinxKcu116',
+                0x00_00_00_0D: 'XilinxKcu1500',
+                0x00_00_00_0E: 'XilinxVcu128',
+            },
+        ))

--- a/shared/rtl/AxiPcieReg.vhd
+++ b/shared/rtl/AxiPcieReg.vhd
@@ -37,6 +37,7 @@ entity AxiPcieReg is
       XIL_DEVICE_G         : string                      := "7SERIES";
       BOOT_PROM_G          : string                      := "BPI";
       DRIVER_TYPE_ID_G     : slv(31 downto 0)            := x"00000000";
+      PCIE_HW_TYPE_G       : slv(31 downto 0)            := HW_TYPE_UNDEFINED_C;
       EN_DEVICE_DNA_G      : boolean                     := true;
       EN_ICAP_G            : boolean                     := true;
       DMA_SIZE_G           : positive range 1 to 16      := 1);
@@ -283,8 +284,11 @@ begin
       -- Application Clock Frequency
       userValues(8) <= appClkFreq;
 
+      -- PCIe Hardware Type
+      userValues(9) <= PCIE_HW_TYPE_G;
+
       -- Set unused to zero
-      for i in 63 downto 9 loop
+      for i in 63 downto 10 loop
          userValues(i) <= x"00000000";
       end loop;
 

--- a/shared/rtl/AxiPcieSharedPkg.vhd
+++ b/shared/rtl/AxiPcieSharedPkg.vhd
@@ -1,0 +1,43 @@
+-------------------------------------------------------------------------------
+-- File       : AxiPcieSharedPkg.vhd
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Shared Package file for AXI PCIe Core
+-------------------------------------------------------------------------------
+-- This file is part of 'axi-pcie-core'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'axi-pcie-core', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+
+package AxiPcieSharedPkg is
+
+   -- List of PCIe Hardware Types
+   constant HW_TYPE_UNDEFINED_C        : slv(31 downto 0) := x"00_00_00_00";
+   constant HW_TYPE_ALPHADATA_KU3_C    : slv(31 downto 0) := x"00_00_00_01";
+   constant HW_TYPE_BITTWARE_XUP_VV8_C : slv(31 downto 0) := x"00_00_00_02";
+   constant HW_TYPE_SLAC_PGP_GEN3_C    : slv(31 downto 0) := x"00_00_00_03";
+   constant HW_TYPE_SLAC_PGP_GEN4_C    : slv(31 downto 0) := x"00_00_00_04";
+   constant HW_TYPE_XILINX_AC701_C     : slv(31 downto 0) := x"00_00_00_05";
+   constant HW_TYPE_XILINX_U50_C       : slv(31 downto 0) := x"00_00_00_06";
+   constant HW_TYPE_XILINX_U200_C      : slv(31 downto 0) := x"00_00_00_07";
+   constant HW_TYPE_XILINX_U250_C      : slv(31 downto 0) := x"00_00_00_08";
+   constant HW_TYPE_XILINX_U280_C      : slv(31 downto 0) := x"00_00_00_09";
+   constant HW_TYPE_XILINX_KC705_C     : slv(31 downto 0) := x"00_00_00_0A";
+   constant HW_TYPE_XILINX_KCU105_C    : slv(31 downto 0) := x"00_00_00_0B";
+   constant HW_TYPE_XILINX_KCU116_C    : slv(31 downto 0) := x"00_00_00_0C";
+   constant HW_TYPE_XILINX_KCU1500_C   : slv(31 downto 0) := x"00_00_00_0D";
+   constant HW_TYPE_XILINX_VCU128_C    : slv(31 downto 0) := x"00_00_00_0E";
+
+end package AxiPcieSharedPkg;


### PR DESCRIPTION
### Description
- The QSFP/SFP I2C mapping can be radically different between different hardware boards
- `PCIE_HW_TYPE_G` give the software the ability to check if the software configuration matches the hardware register