### PR TITLE
Release Candidate v3.13.0

### DIFF
--- a/hardware/XilinxAlveoU200/ddr/rtl/MigDmaBuffer.vhd
+++ b/hardware/XilinxAlveoU200/ddr/rtl/MigDmaBuffer.vhd
@@ -26,9 +26,11 @@ use axi_pcie_core.MigPkg.all;
 
 entity MigDmaBuffer is
    generic (
-      TPD_G             : time                  := 1 ns;
-      DMA_SIZE_G        : positive range 1 to 8 := 8;
+      TPD_G             : time                     := 1 ns;
+      DMA_SIZE_G        : positive range 1 to 8    := 8;
       DMA_AXIS_CONFIG_G : AxiStreamConfigType;
+      BURST_BYTES_G     : positive range 1 to 4096 := 1024;
+      RD_PEND_THRESH_G  : positive                 := 1;  -- In units of bytes
       AXIL_BASE_ADDR_G  : slv(31 downto 0));
    port (
       -- AXI-Lite Interface (axilClk domain)
@@ -177,7 +179,9 @@ begin
             AXIS_CONFIG_G      => DMA_AXIS_CONFIG_G,
             -- AXI4 Configurations
             AXI_BASE_ADDR_G    => AXI_BASE_ADDR_C(i),
-            AXI_CONFIG_G       => DMA_AXI_CONFIG_C)
+            AXI_CONFIG_G       => DMA_AXI_CONFIG_C,
+            BURST_BYTES_G      => BURST_BYTES_G,
+            RD_PEND_THRESH_G   => RD_PEND_THRESH_G)
          port map (
             -- AXI4 Interface (axiClk domain)
             axiClk          => axisClk,

--- a/hardware/XilinxKcu1500/ddr/rtl/MigDmaBuffer.vhd
+++ b/hardware/XilinxKcu1500/ddr/rtl/MigDmaBuffer.vhd
@@ -26,9 +26,11 @@ use axi_pcie_core.MigPkg.all;
 
 entity MigDmaBuffer is
    generic (
-      TPD_G             : time                  := 1 ns;
-      DMA_SIZE_G        : positive range 1 to 8 := 8;
+      TPD_G             : time                     := 1 ns;
+      DMA_SIZE_G        : positive range 1 to 8    := 8;
       DMA_AXIS_CONFIG_G : AxiStreamConfigType;
+      BURST_BYTES_G     : positive range 1 to 4096 := 1024;
+      RD_PEND_THRESH_G  : positive                 := 1;  -- In units of bytes
       AXIL_BASE_ADDR_G  : slv(31 downto 0));
    port (
       -- AXI-Lite Interface (axilClk domain)
@@ -177,7 +179,9 @@ begin
             AXIS_CONFIG_G      => DMA_AXIS_CONFIG_G,
             -- AXI4 Configurations
             AXI_BASE_ADDR_G    => AXI_BASE_ADDR_C(i),
-            AXI_CONFIG_G       => DMA_AXI_CONFIG_C)
+            AXI_CONFIG_G       => DMA_AXI_CONFIG_C,
+            BURST_BYTES_G      => BURST_BYTES_G,
+            RD_PEND_THRESH_G   => RD_PEND_THRESH_G)
          port map (
             -- AXI4 Interface (axiClk domain)
             axiClk          => axisClk,

--- a/hardware/XilinxVariumC1100/hbm/HbmDmaBuffer.vhd
+++ b/hardware/XilinxVariumC1100/hbm/HbmDmaBuffer.vhd
@@ -25,9 +25,11 @@ library axi_pcie_core;
 
 entity HbmDmaBuffer is
    generic (
-      TPD_G             : time                  := 1 ns;
-      DMA_SIZE_G        : positive range 1 to 8 := 8;
+      TPD_G             : time                     := 1 ns;
+      DMA_SIZE_G        : positive range 1 to 8    := 8;
       DMA_AXIS_CONFIG_G : AxiStreamConfigType;
+      BURST_BYTES_G     : positive range 1 to 4096 := 512;
+      RD_PEND_THRESH_G  : positive                 := 2048;  -- In units of bytes
       AXIL_BASE_ADDR_G  : slv(31 downto 0));
    port (
       -- HBM Interface
@@ -553,8 +555,8 @@ begin
             -- AXI4 Configurations
             AXI_BASE_ADDR_G    => AXI_BASE_ADDR_C(i),
             AXI_CONFIG_G       => DMA_AXI_CONFIG_C,
-            BURST_BYTES_G      => 512,
-            RD_PEND_THRESH_G   => 2048)
+            BURST_BYTES_G      => BURST_BYTES_G,
+            RD_PEND_THRESH_G   => RD_PEND_THRESH_G)
          port map (
             -- AXI4 Interface (axiClk domain)
             axiClk          => axisClk,


### PR DESCRIPTION
### Description
- [exposing BURST_BYTES_G/RD_PEND_THRESH_G and compromising/optimizing migDmaBuffer.vhd default for high rate & high bandwidth](https://github.com/slaclab/axi-pcie-core/commit/138fc202624e5cbf8363984f55168c837cce4503)