### PR TITLE
Reset buffer index when read/write enable = 0, and ensure buffer index stays in range

### DIFF
--- a/protocol/gpuAsync/rtl/AxiPcieGpuAsyncControl.vhd
+++ b/protocol/gpuAsync/rtl/AxiPcieGpuAsyncControl.vhd
@@ -323,7 +323,7 @@ begin
                      v.wrLatencyEn(conv_integer(r.nextWriteIdx)) := '1';
                      v.wrLatency(conv_integer(r.nextWriteIdx))   := (others => '0');
 
-                     if r.nextWriteIdx = r.writeCount then
+                     if r.nextWriteIdx >= r.writeCount then
                         v.nextWriteIdx := (others => '0');
                      else
                         v.nextWriteIdx := r.nextWriteIdx + 1;
@@ -331,6 +331,10 @@ begin
                   end if;
 
                end if;
+            end if;
+
+            if r.writeEnable = '0' then
+               v.nextWriteIdx := (others => '0');
             end if;
 
          when MOVE_S =>
@@ -362,7 +366,7 @@ begin
                v.remoteReadEn(conv_integer(r.nextReadIdx)) := '0';
 
 
-               if r.nextReadIdx = r.readCount then
+               if r.nextReadIdx >= r.readCount then
                   v.nextReadIdx := (others => '0');
                else
                   v.nextReadIdx := r.nextReadIdx + 1;
@@ -382,6 +386,10 @@ begin
                v.dmaRdDescReq.address(63 downto 32) := r.remoteReadAddrH(conv_integer(r.nextReadIdx));
 
                v.txState := MOVE_S;
+            end if;
+
+            if r.readEnable = '0' then
+               v.nextReadIdx := (others => '0');
             end if;
 
          when MOVE_S =>


### PR DESCRIPTION
This fixes a couple of problems that popped up during testing:
1. Single-threaded software could get confused if the buffer index does not start at 0 for a given "session". Currently, there is no way for software to detect the buffer index or reset it (without triggering userReset or something).
2. If we run the software with 4 buffers, terminate when the buffer index > 1, then run the software with 2 buffers, the FPGA ends up in a weird state where the buffer index is out of range.

I tested this firmware on daq-tst-dev06.