### PR TITLE
Adding GPU ASYNC AXI-Lite interface to axi-pcie-core with fixed address offset

### DIFF
--- a/hardware/AbacoPc821/rtl/AbacoPc821Core.vhd
+++ b/hardware/AbacoPc821/rtl/AbacoPc821Core.vhd
@@ -61,7 +61,7 @@ entity AbacoPc821Core is
       gpuReadMaster   : out   AxiLiteReadMasterType;
       gpuReadSlave    : in    AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       gpuWriteMaster  : out   AxiLiteWriteMasterType;
-      gpuWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------

--- a/hardware/AbacoPc821/rtl/AbacoPc821Core.vhd
+++ b/hardware/AbacoPc821/rtl/AbacoPc821Core.vhd
@@ -51,12 +51,17 @@ entity AbacoPc821Core is
       dmaIbMasters    : in    AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
       dmaIbSlaves     : out   AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
       -- Application AXI-Lite Interfaces [0x00100000:0x00FFFFFF] (appClk domain)
-      appClk          : in    sl;
-      appRst          : in    sl;
+      appClk          : in    sl                    := '0';
+      appRst          : in    sl                    := '1';
       appReadMaster   : out   AxiLiteReadMasterType;
-      appReadSlave    : in    AxiLiteReadSlaveType;
+      appReadSlave    : in    AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       appWriteMaster  : out   AxiLiteWriteMasterType;
-      appWriteSlave   : in    AxiLiteWriteSlaveType;
+      appWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
+      -- GPU AXI-Lite Interfaces [0x00028000:0x00028FFF] (appClk domain)
+      gpuReadMaster   : out   AxiLiteReadMasterType;
+      gpuReadSlave    : in    AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteMaster  : out   AxiLiteWriteMasterType;
+      gpuWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------
@@ -208,6 +213,11 @@ begin
          appReadSlave        => appReadSlave,
          appWriteMaster      => appWriteMaster,
          appWriteSlave       => appWriteSlave,
+         -- (Optional) GPU AXI-Lite Interfaces
+         gpuReadMaster       => gpuReadMaster,
+         gpuReadSlave        => gpuReadSlave,
+         gpuWriteMaster      => gpuWriteMaster,
+         gpuWriteSlave       => gpuWriteSlave,
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,

--- a/hardware/AlphaDataKu3/rtl/AlphaDataKu3Core.vhd
+++ b/hardware/AlphaDataKu3/rtl/AlphaDataKu3Core.vhd
@@ -80,7 +80,7 @@ entity AlphaDataKu3Core is
       gpuReadMaster   : out AxiLiteReadMasterType;
       gpuReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       gpuWriteMaster  : out AxiLiteWriteMasterType;
-      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------

--- a/hardware/AlphaDataKu3/rtl/AlphaDataKu3Core.vhd
+++ b/hardware/AlphaDataKu3/rtl/AlphaDataKu3Core.vhd
@@ -70,12 +70,17 @@ entity AlphaDataKu3Core is
       dmaIbMasters    : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
       dmaIbSlaves     : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
       -- Application AXI-Lite Interfaces [0x00100000:0x00FFFFFF] (appClk domain)
-      appClk          : in  sl;
-      appRst          : in  sl;
+      appClk          : in  sl                    := '0';
+      appRst          : in  sl                    := '1';
       appReadMaster   : out AxiLiteReadMasterType;
-      appReadSlave    : in  AxiLiteReadSlaveType;
+      appReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       appWriteMaster  : out AxiLiteWriteMasterType;
-      appWriteSlave   : in  AxiLiteWriteSlaveType;
+      appWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
+      -- GPU AXI-Lite Interfaces [0x00028000:0x00028FFF] (appClk domain)
+      gpuReadMaster   : out AxiLiteReadMasterType;
+      gpuReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteMaster  : out AxiLiteWriteMasterType;
+      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------
@@ -227,6 +232,11 @@ begin
          appReadSlave        => appReadSlave,
          appWriteMaster      => appWriteMaster,
          appWriteSlave       => appWriteSlave,
+         -- (Optional) GPU AXI-Lite Interfaces
+         gpuReadMaster       => gpuReadMaster,
+         gpuReadSlave        => gpuReadSlave,
+         gpuWriteMaster      => gpuWriteMaster,
+         gpuWriteSlave       => gpuWriteSlave,
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset);

--- a/hardware/BittWareXupVv8/core/BittWareXupVv8Core.vhd
+++ b/hardware/BittWareXupVv8/core/BittWareXupVv8Core.vhd
@@ -66,6 +66,11 @@ entity BittWareXupVv8Core is
       appReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       appWriteMaster  : out AxiLiteWriteMasterType;
       appWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
+      -- GPU AXI-Lite Interfaces [0x00028000:0x00028FFF] (appClk domain)
+      gpuReadMaster   : out AxiLiteReadMasterType;
+      gpuReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteMaster  : out AxiLiteWriteMasterType;
+      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------
@@ -255,6 +260,11 @@ begin
          appReadSlave        => appReadSlave,
          appWriteMaster      => appWriteMaster,
          appWriteSlave       => appWriteSlave,
+         -- (Optional) GPU AXI-Lite Interfaces
+         gpuReadMaster       => gpuReadMaster,
+         gpuReadSlave        => gpuReadSlave,
+         gpuWriteMaster      => gpuWriteMaster,
+         gpuWriteSlave       => gpuWriteSlave,
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,

--- a/hardware/BittWareXupVv8/core/BittWareXupVv8Core.vhd
+++ b/hardware/BittWareXupVv8/core/BittWareXupVv8Core.vhd
@@ -70,7 +70,7 @@ entity BittWareXupVv8Core is
       gpuReadMaster   : out AxiLiteReadMasterType;
       gpuReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       gpuWriteMaster  : out AxiLiteWriteMasterType;
-      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------

--- a/hardware/SlacPgpCardG4/rtl/SlacPgpCardG4Core.vhd
+++ b/hardware/SlacPgpCardG4/rtl/SlacPgpCardG4Core.vhd
@@ -71,7 +71,7 @@ entity SlacPgpCardG4Core is
       gpuReadMaster   : out   AxiLiteReadMasterType;
       gpuReadSlave    : in    AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       gpuWriteMaster  : out   AxiLiteWriteMasterType;
-      gpuWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------

--- a/hardware/SlacPgpCardG4/rtl/SlacPgpCardG4Core.vhd
+++ b/hardware/SlacPgpCardG4/rtl/SlacPgpCardG4Core.vhd
@@ -67,6 +67,11 @@ entity SlacPgpCardG4Core is
       appReadSlave    : in    AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       appWriteMaster  : out   AxiLiteWriteMasterType;
       appWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
+      -- GPU AXI-Lite Interfaces [0x00028000:0x00028FFF] (appClk domain)
+      gpuReadMaster   : out   AxiLiteReadMasterType;
+      gpuReadSlave    : in    AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteMaster  : out   AxiLiteWriteMasterType;
+      gpuWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------
@@ -382,6 +387,11 @@ begin
          appReadSlave        => appReadSlave,
          appWriteMaster      => appWriteMaster,
          appWriteSlave       => appWriteSlave,
+         -- (Optional) GPU AXI-Lite Interfaces
+         gpuReadMaster       => gpuReadMaster,
+         gpuReadSlave        => gpuReadSlave,
+         gpuWriteMaster      => gpuWriteMaster,
+         gpuWriteSlave       => gpuWriteSlave,
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,

--- a/hardware/XilinxAlveoU200/core/XilinxAlveoU200Core.vhd
+++ b/hardware/XilinxAlveoU200/core/XilinxAlveoU200Core.vhd
@@ -73,7 +73,7 @@ entity XilinxAlveoU200Core is
       gpuReadMaster   : out   AxiLiteReadMasterType;
       gpuReadSlave    : in    AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       gpuWriteMaster  : out   AxiLiteWriteMasterType;
-      gpuWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------

--- a/hardware/XilinxAlveoU200/core/XilinxAlveoU200Core.vhd
+++ b/hardware/XilinxAlveoU200/core/XilinxAlveoU200Core.vhd
@@ -69,6 +69,11 @@ entity XilinxAlveoU200Core is
       appReadSlave    : in    AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       appWriteMaster  : out   AxiLiteWriteMasterType;
       appWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
+      -- GPU AXI-Lite Interfaces [0x00028000:0x00028FFF] (appClk domain)
+      gpuReadMaster   : out   AxiLiteReadMasterType;
+      gpuReadSlave    : in    AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteMaster  : out   AxiLiteWriteMasterType;
+      gpuWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------
@@ -423,6 +428,11 @@ begin
          appReadSlave        => appReadSlave,
          appWriteMaster      => appWriteMaster,
          appWriteSlave       => appWriteSlave,
+         -- (Optional) GPU AXI-Lite Interfaces
+         gpuReadMaster       => gpuReadMaster,
+         gpuReadSlave        => gpuReadSlave,
+         gpuWriteMaster      => gpuWriteMaster,
+         gpuWriteSlave       => gpuWriteSlave,
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,
@@ -435,25 +445,25 @@ begin
    U_STARTUPE3 : STARTUPE3
       generic map (
          PROG_USR      => "FALSE",  -- Activate program event security feature. Requires encrypted bitstreams.
-         SIM_CCLK_FREQ => 0.0)          -- Set the Configuration Clock Frequency(ns) for simulation
+         SIM_CCLK_FREQ => 0.0)  -- Set the Configuration Clock Frequency(ns) for simulation
       port map (
-         CFGCLK    => open,             -- 1-bit output: Configuration main clock output
+         CFGCLK    => open,  -- 1-bit output: Configuration main clock output
          CFGMCLK   => open,  -- 1-bit output: Configuration internal oscillator clock output
-         DI        => di,               -- 4-bit output: Allow receiving on the D[3:0] input pins
+         DI        => di,  -- 4-bit output: Allow receiving on the D[3:0] input pins
          EOS       => open,  -- 1-bit output: Active high output signal indicating the End Of Startup.
-         PREQ      => open,             -- 1-bit output: PROGRAM request to fabric output
-         DO        => do,               -- 4-bit input: Allows control of the D[3:0] pin outputs
-         DTS       => "1110",           -- 4-bit input: Allows tristate of the D[3:0] pins
-         FCSBO     => bootCsL(0),       -- 1-bit input: Contols the FCS_B pin for flash access
+         PREQ      => open,  -- 1-bit output: PROGRAM request to fabric output
+         DO        => do,  -- 4-bit input: Allows control of the D[3:0] pin outputs
+         DTS       => "1110",  -- 4-bit input: Allows tristate of the D[3:0] pins
+         FCSBO     => bootCsL(0),  -- 1-bit input: Contols the FCS_B pin for flash access
          FCSBTS    => '0',              -- 1-bit input: Tristate the FCS_B pin
          GSR       => '0',  -- 1-bit input: Global Set/Reset input (GSR cannot be used for the port name)
          GTS       => '0',  -- 1-bit input: Global 3-state input (GTS cannot be used for the port name)
          KEYCLEARB => '0',  -- 1-bit input: Clear AES Decrypter Key input from Battery-Backed RAM (BBRAM)
-         PACK      => '0',              -- 1-bit input: PROGRAM acknowledge input
+         PACK      => '0',  -- 1-bit input: PROGRAM acknowledge input
          USRCCLKO  => sck,              -- 1-bit input: User CCLK input
-         USRCCLKTS => '0',              -- 1-bit input: User CCLK 3-state enable input
-         USRDONEO  => '1',              -- 1-bit input: User DONE pin output control
-         USRDONETS => '0');             -- 1-bit input: User DONE 3-state enable output
+         USRCCLKTS => '0',  -- 1-bit input: User CCLK 3-state enable input
+         USRDONEO  => '1',  -- 1-bit input: User DONE pin output control
+         USRDONETS => '0');  -- 1-bit input: User DONE 3-state enable output
 
    do          <= "111" & bootMosi(0);
    bootMiso(0) <= di(1);

--- a/hardware/XilinxAlveoU250/core/XilinxAlveoU250Core.vhd
+++ b/hardware/XilinxAlveoU250/core/XilinxAlveoU250Core.vhd
@@ -71,7 +71,7 @@ entity XilinxAlveoU250Core is
       gpuReadMaster   : out AxiLiteReadMasterType;
       gpuReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       gpuWriteMaster  : out AxiLiteWriteMasterType;
-      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------

--- a/hardware/XilinxAlveoU250/core/XilinxAlveoU250Core.vhd
+++ b/hardware/XilinxAlveoU250/core/XilinxAlveoU250Core.vhd
@@ -67,6 +67,11 @@ entity XilinxAlveoU250Core is
       appReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       appWriteMaster  : out AxiLiteWriteMasterType;
       appWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
+      -- GPU AXI-Lite Interfaces [0x00028000:0x00028FFF] (appClk domain)
+      gpuReadMaster   : out AxiLiteReadMasterType;
+      gpuReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteMaster  : out AxiLiteWriteMasterType;
+      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------
@@ -263,6 +268,11 @@ begin
          appReadSlave        => appReadSlave,
          appWriteMaster      => appWriteMaster,
          appWriteSlave       => appWriteSlave,
+         -- (Optional) GPU AXI-Lite Interfaces
+         gpuReadMaster       => gpuReadMaster,
+         gpuReadSlave        => gpuReadSlave,
+         gpuWriteMaster      => gpuWriteMaster,
+         gpuWriteSlave       => gpuWriteSlave,
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,

--- a/hardware/XilinxAlveoU280/pcie-3x16/rtl/XilinxAlveoU280Core.vhd
+++ b/hardware/XilinxAlveoU280/pcie-3x16/rtl/XilinxAlveoU280Core.vhd
@@ -67,6 +67,11 @@ entity XilinxAlveoU280Core is
       appReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       appWriteMaster  : out AxiLiteWriteMasterType;
       appWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
+      -- GPU AXI-Lite Interfaces [0x00028000:0x00028FFF] (appClk domain)
+      gpuReadMaster   : out AxiLiteReadMasterType;
+      gpuReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteMaster  : out AxiLiteWriteMasterType;
+      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------
@@ -259,6 +264,11 @@ begin
          appReadSlave        => appReadSlave,
          appWriteMaster      => appWriteMaster,
          appWriteSlave       => appWriteSlave,
+         -- (Optional) GPU AXI-Lite Interfaces
+         gpuReadMaster       => gpuReadMaster,
+         gpuReadSlave        => gpuReadSlave,
+         gpuWriteMaster      => gpuWriteMaster,
+         gpuWriteSlave       => gpuWriteSlave,
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,

--- a/hardware/XilinxAlveoU280/pcie-3x16/rtl/XilinxAlveoU280Core.vhd
+++ b/hardware/XilinxAlveoU280/pcie-3x16/rtl/XilinxAlveoU280Core.vhd
@@ -71,7 +71,7 @@ entity XilinxAlveoU280Core is
       gpuReadMaster   : out AxiLiteReadMasterType;
       gpuReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       gpuWriteMaster  : out AxiLiteWriteMasterType;
-      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------

--- a/hardware/XilinxAlveoU50/pcie-3x16/rtl/XilinxAlveoU50Core.vhd
+++ b/hardware/XilinxAlveoU50/pcie-3x16/rtl/XilinxAlveoU50Core.vhd
@@ -67,6 +67,11 @@ entity XilinxAlveoU50Core is
       appReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       appWriteMaster  : out AxiLiteWriteMasterType;
       appWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
+      -- GPU AXI-Lite Interfaces [0x00028000:0x00028FFF] (appClk domain)
+      gpuReadMaster   : out AxiLiteReadMasterType;
+      gpuReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteMaster  : out AxiLiteWriteMasterType;
+      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------
@@ -250,6 +255,11 @@ begin
          appReadSlave        => appReadSlave,
          appWriteMaster      => appWriteMaster,
          appWriteSlave       => appWriteSlave,
+         -- (Optional) GPU AXI-Lite Interfaces
+         gpuReadMaster       => gpuReadMaster,
+         gpuReadSlave        => gpuReadSlave,
+         gpuWriteMaster      => gpuWriteMaster,
+         gpuWriteSlave       => gpuWriteSlave,
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,

--- a/hardware/XilinxAlveoU50/pcie-3x16/rtl/XilinxAlveoU50Core.vhd
+++ b/hardware/XilinxAlveoU50/pcie-3x16/rtl/XilinxAlveoU50Core.vhd
@@ -71,7 +71,7 @@ entity XilinxAlveoU50Core is
       gpuReadMaster   : out AxiLiteReadMasterType;
       gpuReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       gpuWriteMaster  : out AxiLiteWriteMasterType;
-      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------

--- a/hardware/XilinxAlveoU55c/pcie-3x16/rtl/XilinxAlveoU55cCore.vhd
+++ b/hardware/XilinxAlveoU55c/pcie-3x16/rtl/XilinxAlveoU55cCore.vhd
@@ -73,7 +73,7 @@ entity XilinxAlveoU55cCore is
       gpuReadMaster   : out   AxiLiteReadMasterType;
       gpuReadSlave    : in    AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       gpuWriteMaster  : out   AxiLiteWriteMasterType;
-      gpuWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------

--- a/hardware/XilinxAlveoU55c/pcie-3x16/rtl/XilinxAlveoU55cCore.vhd
+++ b/hardware/XilinxAlveoU55c/pcie-3x16/rtl/XilinxAlveoU55cCore.vhd
@@ -69,6 +69,11 @@ entity XilinxAlveoU55cCore is
       appReadSlave    : in    AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       appWriteMaster  : out   AxiLiteWriteMasterType;
       appWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
+      -- GPU AXI-Lite Interfaces [0x00028000:0x00028FFF] (appClk domain)
+      gpuReadMaster   : out   AxiLiteReadMasterType;
+      gpuReadSlave    : in    AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteMaster  : out   AxiLiteWriteMasterType;
+      gpuWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------
@@ -302,6 +307,11 @@ begin
          appReadSlave        => appReadSlave,
          appWriteMaster      => appWriteMaster,
          appWriteSlave       => appWriteSlave,
+         -- (Optional) GPU AXI-Lite Interfaces
+         gpuReadMaster       => gpuReadMaster,
+         gpuReadSlave        => gpuReadSlave,
+         gpuWriteMaster      => gpuWriteMaster,
+         gpuWriteSlave       => gpuWriteSlave,
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,

--- a/hardware/XilinxAlveoU55c/pcie-4x8/rtl/XilinxAlveoU55cCore.vhd
+++ b/hardware/XilinxAlveoU55c/pcie-4x8/rtl/XilinxAlveoU55cCore.vhd
@@ -73,7 +73,7 @@ entity XilinxAlveoU55cCore is
       gpuReadMaster   : out   AxiLiteReadMasterType;
       gpuReadSlave    : in    AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       gpuWriteMaster  : out   AxiLiteWriteMasterType;
-      gpuWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------

--- a/hardware/XilinxAlveoU55c/pcie-4x8/rtl/XilinxAlveoU55cCore.vhd
+++ b/hardware/XilinxAlveoU55c/pcie-4x8/rtl/XilinxAlveoU55cCore.vhd
@@ -69,6 +69,11 @@ entity XilinxAlveoU55cCore is
       appReadSlave    : in    AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       appWriteMaster  : out   AxiLiteWriteMasterType;
       appWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
+      -- GPU AXI-Lite Interfaces [0x00028000:0x00028FFF] (appClk domain)
+      gpuReadMaster   : out   AxiLiteReadMasterType;
+      gpuReadSlave    : in    AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteMaster  : out   AxiLiteWriteMasterType;
+      gpuWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------
@@ -302,6 +307,11 @@ begin
          appReadSlave        => appReadSlave,
          appWriteMaster      => appWriteMaster,
          appWriteSlave       => appWriteSlave,
+         -- (Optional) GPU AXI-Lite Interfaces
+         gpuReadMaster       => gpuReadMaster,
+         gpuReadSlave        => gpuReadSlave,
+         gpuWriteMaster      => gpuWriteMaster,
+         gpuWriteSlave       => gpuWriteSlave,
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,

--- a/hardware/XilinxKcu105/rtl/XilinxKcu105Core.vhd
+++ b/hardware/XilinxKcu105/rtl/XilinxKcu105Core.vhd
@@ -65,7 +65,7 @@ entity XilinxKcu105Core is
       gpuReadMaster   : out AxiLiteReadMasterType;
       gpuReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       gpuWriteMaster  : out AxiLiteWriteMasterType;
-      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------

--- a/hardware/XilinxKcu105/rtl/XilinxKcu105Core.vhd
+++ b/hardware/XilinxKcu105/rtl/XilinxKcu105Core.vhd
@@ -55,12 +55,17 @@ entity XilinxKcu105Core is
       dmaIbMasters    : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
       dmaIbSlaves     : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
       -- Application AXI-Lite Interfaces [0x00100000:0x00FFFFFF] (appClk domain)
-      appClk          : in  sl;
-      appRst          : in  sl;
+      appClk          : in  sl                    := '0';
+      appRst          : in  sl                    := '1';
       appReadMaster   : out AxiLiteReadMasterType;
-      appReadSlave    : in  AxiLiteReadSlaveType;
+      appReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       appWriteMaster  : out AxiLiteWriteMasterType;
-      appWriteSlave   : in  AxiLiteWriteSlaveType;
+      appWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
+      -- GPU AXI-Lite Interfaces [0x00028000:0x00028FFF] (appClk domain)
+      gpuReadMaster   : out AxiLiteReadMasterType;
+      gpuReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteMaster  : out AxiLiteWriteMasterType;
+      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------
@@ -221,6 +226,11 @@ begin
          appReadSlave        => appReadSlave,
          appWriteMaster      => appWriteMaster,
          appWriteSlave       => appWriteSlave,
+         -- (Optional) GPU AXI-Lite Interfaces
+         gpuReadMaster       => gpuReadMaster,
+         gpuReadSlave        => gpuReadSlave,
+         gpuWriteMaster      => gpuWriteMaster,
+         gpuWriteSlave       => gpuWriteSlave,
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,

--- a/hardware/XilinxKcu116/rtl/XilinxKcu116Core.vhd
+++ b/hardware/XilinxKcu116/rtl/XilinxKcu116Core.vhd
@@ -55,12 +55,17 @@ entity XilinxKcu116Core is
       dmaIbMasters    : in  AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
       dmaIbSlaves     : out AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
       -- Application AXI-Lite Interfaces [0x00100000:0x00FFFFFF] (appClk domain)
-      appClk          : in  sl;
-      appRst          : in  sl;
+      appClk          : in  sl                    := '0';
+      appRst          : in  sl                    := '1';
       appReadMaster   : out AxiLiteReadMasterType;
-      appReadSlave    : in  AxiLiteReadSlaveType;
+      appReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       appWriteMaster  : out AxiLiteWriteMasterType;
-      appWriteSlave   : in  AxiLiteWriteSlaveType;
+      appWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
+      -- GPU AXI-Lite Interfaces [0x00028000:0x00028FFF] (appClk domain)
+      gpuReadMaster   : out AxiLiteReadMasterType;
+      gpuReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteMaster  : out AxiLiteWriteMasterType;
+      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------
@@ -221,6 +226,11 @@ begin
          appReadSlave        => appReadSlave,
          appWriteMaster      => appWriteMaster,
          appWriteSlave       => appWriteSlave,
+         -- (Optional) GPU AXI-Lite Interfaces
+         gpuReadMaster       => gpuReadMaster,
+         gpuReadSlave        => gpuReadSlave,
+         gpuWriteMaster      => gpuWriteMaster,
+         gpuWriteSlave       => gpuWriteSlave,
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,

--- a/hardware/XilinxKcu116/rtl/XilinxKcu116Core.vhd
+++ b/hardware/XilinxKcu116/rtl/XilinxKcu116Core.vhd
@@ -65,7 +65,7 @@ entity XilinxKcu116Core is
       gpuReadMaster   : out AxiLiteReadMasterType;
       gpuReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       gpuWriteMaster  : out AxiLiteWriteMasterType;
-      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------

--- a/hardware/XilinxKcu1500/pcie-extended/rtl/XilinxKcu1500PcieExtendedCore.vhd
+++ b/hardware/XilinxKcu1500/pcie-extended/rtl/XilinxKcu1500PcieExtendedCore.vhd
@@ -65,6 +65,11 @@ entity XilinxKcu1500PcieExtendedCore is
       appReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       appWriteMaster  : out AxiLiteWriteMasterType;
       appWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
+      -- GPU AXI-Lite Interfaces [0x00028000:0x00028FFF] (appClk domain)
+      gpuReadMaster   : out AxiLiteReadMasterType;
+      gpuReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteMaster  : out AxiLiteWriteMasterType;
+      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------
@@ -228,6 +233,11 @@ begin
          appReadSlave        => appReadSlave,
          appWriteMaster      => appWriteMaster,
          appWriteSlave       => appWriteSlave,
+         -- (Optional) GPU AXI-Lite Interfaces
+         gpuReadMaster       => gpuReadMaster,
+         gpuReadSlave        => gpuReadSlave,
+         gpuWriteMaster      => gpuWriteMaster,
+         gpuWriteSlave       => gpuWriteSlave,
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset);

--- a/hardware/XilinxKcu1500/pcie-extended/rtl/XilinxKcu1500PcieExtendedCore.vhd
+++ b/hardware/XilinxKcu1500/pcie-extended/rtl/XilinxKcu1500PcieExtendedCore.vhd
@@ -69,7 +69,7 @@ entity XilinxKcu1500PcieExtendedCore is
       gpuReadMaster   : out AxiLiteReadMasterType;
       gpuReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       gpuWriteMaster  : out AxiLiteWriteMasterType;
-      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------

--- a/hardware/XilinxKcu1500/rtl/XilinxKcu1500Core.vhd
+++ b/hardware/XilinxKcu1500/rtl/XilinxKcu1500Core.vhd
@@ -78,7 +78,7 @@ entity XilinxKcu1500Core is
       gpuReadMaster   : out   AxiLiteReadMasterType;
       gpuReadSlave    : in    AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       gpuWriteMaster  : out   AxiLiteWriteMasterType;
-      gpuWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------

--- a/hardware/XilinxKcu1500/rtl/XilinxKcu1500Core.vhd
+++ b/hardware/XilinxKcu1500/rtl/XilinxKcu1500Core.vhd
@@ -74,6 +74,11 @@ entity XilinxKcu1500Core is
       appReadSlave    : in    AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       appWriteMaster  : out   AxiLiteWriteMasterType;
       appWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
+      -- GPU AXI-Lite Interfaces [0x00028000:0x00028FFF] (appClk domain)
+      gpuReadMaster   : out   AxiLiteReadMasterType;
+      gpuReadSlave    : in    AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteMaster  : out   AxiLiteWriteMasterType;
+      gpuWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------
@@ -222,8 +227,8 @@ begin
 
    U_BUFG : BUFG
       port map(
-         I  => userClk,
-         O  => userClk156);
+         I => userClk,
+         O => userClk156);
 
    i2cRstL      <= not(systemReset);
    qsfp0RstL    <= not(systemReset);
@@ -456,6 +461,11 @@ begin
          appReadSlave        => appReadSlave,
          appWriteMaster      => appWriteMaster,
          appWriteSlave       => appWriteSlave,
+         -- (Optional) GPU AXI-Lite Interfaces
+         gpuReadMaster       => gpuReadMaster,
+         gpuReadSlave        => gpuReadSlave,
+         gpuWriteMaster      => gpuWriteMaster,
+         gpuWriteSlave       => gpuWriteSlave,
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,

--- a/hardware/XilinxVariumC1100/pcie-3x16/rtl/XilinxVariumC1100Core.vhd
+++ b/hardware/XilinxVariumC1100/pcie-3x16/rtl/XilinxVariumC1100Core.vhd
@@ -69,6 +69,11 @@ entity XilinxVariumC1100Core is
       appReadSlave    : in    AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       appWriteMaster  : out   AxiLiteWriteMasterType;
       appWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
+      -- GPU AXI-Lite Interfaces [0x00028000:0x00028FFF] (appClk domain)
+      gpuReadMaster   : out   AxiLiteReadMasterType;
+      gpuReadSlave    : in    AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteMaster  : out   AxiLiteWriteMasterType;
+      gpuWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------
@@ -302,6 +307,11 @@ begin
          appReadSlave        => appReadSlave,
          appWriteMaster      => appWriteMaster,
          appWriteSlave       => appWriteSlave,
+         -- (Optional) GPU AXI-Lite Interfaces
+         gpuReadMaster       => gpuReadMaster,
+         gpuReadSlave        => gpuReadSlave,
+         gpuWriteMaster      => gpuWriteMaster,
+         gpuWriteSlave       => gpuWriteSlave,
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,

--- a/hardware/XilinxVariumC1100/pcie-3x16/rtl/XilinxVariumC1100Core.vhd
+++ b/hardware/XilinxVariumC1100/pcie-3x16/rtl/XilinxVariumC1100Core.vhd
@@ -73,7 +73,7 @@ entity XilinxVariumC1100Core is
       gpuReadMaster   : out   AxiLiteReadMasterType;
       gpuReadSlave    : in    AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       gpuWriteMaster  : out   AxiLiteWriteMasterType;
-      gpuWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------

--- a/hardware/XilinxVariumC1100/pcie-4x8/rtl/XilinxVariumC1100Core.vhd
+++ b/hardware/XilinxVariumC1100/pcie-4x8/rtl/XilinxVariumC1100Core.vhd
@@ -69,6 +69,11 @@ entity XilinxVariumC1100Core is
       appReadSlave    : in    AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       appWriteMaster  : out   AxiLiteWriteMasterType;
       appWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
+      -- GPU AXI-Lite Interfaces [0x00028000:0x00028FFF] (appClk domain)
+      gpuReadMaster   : out   AxiLiteReadMasterType;
+      gpuReadSlave    : in    AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteMaster  : out   AxiLiteWriteMasterType;
+      gpuWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------
@@ -302,6 +307,11 @@ begin
          appReadSlave        => appReadSlave,
          appWriteMaster      => appWriteMaster,
          appWriteSlave       => appWriteSlave,
+         -- (Optional) GPU AXI-Lite Interfaces
+         gpuReadMaster       => gpuReadMaster,
+         gpuReadSlave        => gpuReadSlave,
+         gpuWriteMaster      => gpuWriteMaster,
+         gpuWriteSlave       => gpuWriteSlave,
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,

--- a/hardware/XilinxVariumC1100/pcie-4x8/rtl/XilinxVariumC1100Core.vhd
+++ b/hardware/XilinxVariumC1100/pcie-4x8/rtl/XilinxVariumC1100Core.vhd
@@ -73,7 +73,7 @@ entity XilinxVariumC1100Core is
       gpuReadMaster   : out   AxiLiteReadMasterType;
       gpuReadSlave    : in    AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       gpuWriteMaster  : out   AxiLiteWriteMasterType;
-      gpuWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteSlave   : in    AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------

--- a/hardware/XilinxVcu128/pcie-3x16/rtl/XilinxVcu128Core.vhd
+++ b/hardware/XilinxVcu128/pcie-3x16/rtl/XilinxVcu128Core.vhd
@@ -71,7 +71,7 @@ entity XilinxVcu128Core is
       gpuReadMaster   : out AxiLiteReadMasterType;
       gpuReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       gpuWriteMaster  : out AxiLiteWriteMasterType;
-      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------

--- a/hardware/XilinxVcu128/pcie-3x16/rtl/XilinxVcu128Core.vhd
+++ b/hardware/XilinxVcu128/pcie-3x16/rtl/XilinxVcu128Core.vhd
@@ -67,6 +67,11 @@ entity XilinxVcu128Core is
       appReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       appWriteMaster  : out AxiLiteWriteMasterType;
       appWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
+      -- GPU AXI-Lite Interfaces [0x00028000:0x00028FFF] (appClk domain)
+      gpuReadMaster   : out AxiLiteReadMasterType;
+      gpuReadSlave    : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
+      gpuWriteMaster  : out AxiLiteWriteMasterType;
+      gpuWriteSlave   : in  AxiLiteWriteSlaveType := AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       -------------------
       --  Top Level Ports
       -------------------
@@ -259,6 +264,11 @@ begin
          appReadSlave        => appReadSlave,
          appWriteMaster      => appWriteMaster,
          appWriteSlave       => appWriteSlave,
+         -- (Optional) GPU AXI-Lite Interfaces
+         gpuReadMaster       => gpuReadMaster,
+         gpuReadSlave        => gpuReadSlave,
+         gpuWriteMaster      => gpuWriteMaster,
+         gpuWriteSlave       => gpuWriteSlave,
          -- Application Force reset
          cardResetOut        => cardReset,
          cardResetIn         => systemReset,

--- a/python/axipcie/_AxiPcieCore.py
+++ b/python/axipcie/_AxiPcieCore.py
@@ -46,12 +46,6 @@ class AxiPcieCore(pr.Device):
             expand       = False,
         ))
 
-        if useGpu:
-            self.add(axipcie.AxiGpuAsyncCore(
-                name     = 'AxiGpuAsyncCore',
-                offset    = 0x28000,
-                expand    = False,
-            ))
         # DMA AXI Stream Inbound Monitor
         self.add(axi.AxiStreamMonAxiL(
             name        = 'DmaIbAxisMon',
@@ -75,6 +69,14 @@ class AxiPcieCore(pr.Device):
                 offset       = 0x10000,
                 expand       = False,
             ))
+
+            # Check if using GpuAsyncCore
+            if useGpu:
+                self.add(axipcie.AxiGpuAsyncCore(
+                    name     = 'AxiGpuAsyncCore',
+                    offset    = 0x28000,
+                    expand    = False,
+                ))
 
             # Check if using BPI PROM (Micron MT28 or Cypress S29GL)
             if (useBpi):

--- a/python/axipcie/_AxiPcieCore.py
+++ b/python/axipcie/_AxiPcieCore.py
@@ -26,6 +26,7 @@ class AxiPcieCore(pr.Device):
     def __init__(self,
                  description = 'Base components of the PCIe firmware core',
                  useBpi      = False,
+                 useGpu      = False,
                  useSpi      = False,
                  numDmaLanes = 1,
                  boardType   = None,
@@ -45,6 +46,12 @@ class AxiPcieCore(pr.Device):
             expand       = False,
         ))
 
+        if useGpu:
+            self.add(axipcie.AxiGpuAsyncCore(
+                name     = 'AxiGpuAsyncCore',
+                offset    = 0x28000,
+                expand    = False,
+            ))
         # DMA AXI Stream Inbound Monitor
         self.add(axi.AxiStreamMonAxiL(
             name        = 'DmaIbAxisMon',

--- a/shared/rtl/AxiPcieReg.vhd
+++ b/shared/rtl/AxiPcieReg.vhd
@@ -64,6 +64,11 @@ entity AxiPcieReg is
       i2cReadSlave        : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_DECERR_C;
       i2cWriteMaster      : out AxiLiteWriteMasterType;
       i2cWriteSlave       : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C;
+      -- GTH AXI-Lite Interfaces
+      gpuReadMaster      : out AxiLiteReadMasterType;
+      gpuReadSlave       : in  AxiLiteReadSlaveType;
+      gpuWriteMaster     : out AxiLiteWriteMasterType;
+      gpuWriteSlave      : in  AxiLiteWriteSlaveType;
       -- Application AXI-Lite Interfaces [0x00100000:0x00FFFFFF] (appClk domain)
       appClk              : in  sl;
       appRst              : in  sl;
@@ -415,6 +420,14 @@ begin
          userReset      => cardResetOut,
          -- Optional: user values
          userValues     => userValues);
+
+   --------------------------------------
+   -- Map the AXI-Lite to AxiGpuAsyncCore
+   --------------------------------------
+  gpuWriteMaster               <= axilWriteMasters(GPU_INDEX_C);
+  axilWriteSlaves(GPU_INDEX_C) <= gpuWriteSlave;
+  gpuReadMaster                <= axilReadMasters(GPU_INDEX_C);
+  axilReadSlaves(GPU_INDEX_C)  <= gpuReadSlave;
 
    -----------------------------
    -- AXI-Lite Boot Flash Module

--- a/shared/rtl/AxiPcieReg.vhd
+++ b/shared/rtl/AxiPcieReg.vhd
@@ -122,6 +122,10 @@ architecture mapping of AxiPcieReg is
          baseAddr     => x"0002_0000",
          addrBits     => 16,
          connectivity => x"FFFF"),
+      GPU_INDEX_C => (
+         baseAddr     => x"0002_8000", 
+         addrBits     => 12, 
+         connectivity => x"FFFF"), 
       BPI_INDEX_C     => (
          baseAddr     => x"0003_0000",
          addrBits     => 16,

--- a/shared/rtl/AxiPcieReg.vhd
+++ b/shared/rtl/AxiPcieReg.vhd
@@ -443,7 +443,7 @@ begin
          mAxiReadMaster  => gpuReadMaster,
          mAxiReadSlave   => gpuReadSlave,
          mAxiWriteMaster => gpuWriteMaster,
-         mAxiWriteSlave  => gpuReadSlave);
+         mAxiWriteSlave  => gpuWriteSlave);
 
    -----------------------------
    -- AXI-Lite Boot Flash Module

--- a/shared/rtl/AxiPcieReg.vhd
+++ b/shared/rtl/AxiPcieReg.vhd
@@ -126,11 +126,11 @@ architecture mapping of AxiPcieReg is
          connectivity => x"FFFF"),
       VERSION_INDEX_C => (
          baseAddr     => x"0002_0000",
-         addrBits     => 16,
+         addrBits     => 15,
          connectivity => x"FFFF"),
       GPU_INDEX_C     => (
          baseAddr     => x"0002_8000",
-         addrBits     => 12,
+         addrBits     => 15,
          connectivity => x"FFFF"),
       BPI_INDEX_C     => (
          baseAddr     => x"0003_0000",
@@ -428,7 +428,7 @@ begin
       generic map (
          TPD_G           => TPD_G,
          COMMON_CLK_G    => false,
-         NUM_ADDR_BITS_G => 12)
+         NUM_ADDR_BITS_G => 15)
       port map (
          -- Slave Interface
          sAxiClk         => axiClk,

--- a/shared/rtl/AxiPcieReg.vhd
+++ b/shared/rtl/AxiPcieReg.vhd
@@ -95,19 +95,20 @@ architecture mapping of AxiPcieReg is
    constant DMA_INDEX_C     : natural := 0;
    constant PHY_INDEX_C     : natural := 1;
    constant VERSION_INDEX_C : natural := 2;
-   constant BPI_INDEX_C     : natural := 3;
-   constant SPI0_INDEX_C    : natural := 4;
-   constant SPI1_INDEX_C    : natural := 5;
-   constant AXIS_MON_IB_C   : natural := 6;
-   constant AXIS_MON_OB_C   : natural := 7;
-   constant I2C_INDEX_C     : natural := 8;
+   constant GPU_INDEX_C    : natural := 3;
+   constant BPI_INDEX_C     : natural := 4;
+   constant SPI0_INDEX_C    : natural := 5;
+   constant SPI1_INDEX_C    : natural := 6;
+   constant AXIS_MON_IB_C   : natural := 7;
+   constant AXIS_MON_OB_C   : natural := 8;
+   constant I2C_INDEX_C     : natural := 9;
    -- constant APP0_INDEX_C    : natural := XXX; -- Now used for PIP interface
-   constant APP1_INDEX_C    : natural := 9;
-   constant APP2_INDEX_C    : natural := 10;
-   constant APP3_INDEX_C    : natural := 11;
-   constant APP4_INDEX_C    : natural := 12;
+   constant APP1_INDEX_C    : natural := 10;
+   constant APP2_INDEX_C    : natural := 11;
+   constant APP3_INDEX_C    : natural := 12;
+   constant APP4_INDEX_C    : natural := 13;
 
-   constant NUM_AXI_MASTERS_C : natural := 13;
+   constant NUM_AXI_MASTERS_C : natural := 14;
 
    constant AXI_CROSSBAR_MASTERS_CONFIG_C : AxiLiteCrossbarMasterConfigArray(NUM_AXI_MASTERS_C-1 downto 0) := (
       DMA_INDEX_C     => (

--- a/shared/rtl/AxiPcieReg.vhd
+++ b/shared/rtl/AxiPcieReg.vhd
@@ -440,9 +440,9 @@ begin
          -- Master Interface
          mAxiClk         => appClk,
          mAxiClkRst      => appRstInt,
-         mAxiReadMaster  => gpuWriteMaster,
-         mAxiReadSlave   => gpuWriteSlave,
-         mAxiWriteMaster => gpuReadMaster,
+         mAxiReadMaster  => gpuReadMaster,
+         mAxiReadSlave   => gpuReadSlave,
+         mAxiWriteMaster => gpuWriteMaster,
          mAxiWriteSlave  => gpuReadSlave);
 
    -----------------------------

--- a/shared/rtl/AxiPcieReg.vhd
+++ b/shared/rtl/AxiPcieReg.vhd
@@ -65,10 +65,10 @@ entity AxiPcieReg is
       i2cWriteMaster      : out AxiLiteWriteMasterType;
       i2cWriteSlave       : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C;
       -- GTH AXI-Lite Interfaces
-      gpuReadMaster      : out AxiLiteReadMasterType;
-      gpuReadSlave       : in  AxiLiteReadSlaveType;
-      gpuWriteMaster     : out AxiLiteWriteMasterType;
-      gpuWriteSlave      : in  AxiLiteWriteSlaveType;
+      gpuReadMaster       : out AxiLiteReadMasterType;
+      gpuReadSlave        : in  AxiLiteReadSlaveType;
+      gpuWriteMaster      : out AxiLiteWriteMasterType;
+      gpuWriteSlave       : in  AxiLiteWriteSlaveType;
       -- Application AXI-Lite Interfaces [0x00100000:0x00FFFFFF] (appClk domain)
       appClk              : in  sl;
       appRst              : in  sl;
@@ -100,7 +100,7 @@ architecture mapping of AxiPcieReg is
    constant DMA_INDEX_C     : natural := 0;
    constant PHY_INDEX_C     : natural := 1;
    constant VERSION_INDEX_C : natural := 2;
-   constant GPU_INDEX_C    : natural := 3;
+   constant GPU_INDEX_C     : natural := 3;
    constant BPI_INDEX_C     : natural := 4;
    constant SPI0_INDEX_C    : natural := 5;
    constant SPI1_INDEX_C    : natural := 6;
@@ -128,10 +128,10 @@ architecture mapping of AxiPcieReg is
          baseAddr     => x"0002_0000",
          addrBits     => 16,
          connectivity => x"FFFF"),
-      GPU_INDEX_C => (
-         baseAddr     => x"0002_8000", 
-         addrBits     => 12, 
-         connectivity => x"FFFF"), 
+      GPU_INDEX_C     => (
+         baseAddr     => x"0002_8000",
+         addrBits     => 12,
+         connectivity => x"FFFF"),
       BPI_INDEX_C     => (
          baseAddr     => x"0003_0000",
          addrBits     => 16,
@@ -424,10 +424,10 @@ begin
    --------------------------------------
    -- Map the AXI-Lite to AxiGpuAsyncCore
    --------------------------------------
-  gpuWriteMaster               <= axilWriteMasters(GPU_INDEX_C);
-  axilWriteSlaves(GPU_INDEX_C) <= gpuWriteSlave;
-  gpuReadMaster                <= axilReadMasters(GPU_INDEX_C);
-  axilReadSlaves(GPU_INDEX_C)  <= gpuReadSlave;
+   gpuWriteMaster               <= axilWriteMasters(GPU_INDEX_C);
+   axilWriteSlaves(GPU_INDEX_C) <= gpuWriteSlave;
+   gpuReadMaster                <= axilReadMasters(GPU_INDEX_C);
+   axilReadSlaves(GPU_INDEX_C)  <= gpuReadSlave;
 
    -----------------------------
    -- AXI-Lite Boot Flash Module

--- a/shared/rtl/AxiPcieReg.vhd
+++ b/shared/rtl/AxiPcieReg.vhd
@@ -64,14 +64,14 @@ entity AxiPcieReg is
       i2cReadSlave        : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_DECERR_C;
       i2cWriteMaster      : out AxiLiteWriteMasterType;
       i2cWriteSlave       : in  AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C;
-      -- Application AXI-Lite Interfaces [0x00028000:0x00028FFF] (appClk domain)
+      -- Application AXI-Lite Interfaces [0x00100000:0x00FFFFFF] (appClk domain)
       appClk              : in  sl;
       appRst              : in  sl;
       appReadMaster       : out AxiLiteReadMasterType;
       appReadSlave        : in  AxiLiteReadSlaveType;
       appWriteMaster      : out AxiLiteWriteMasterType;
       appWriteSlave       : in  AxiLiteWriteSlaveType;
-      -- GPU AXI-Lite Interfaces [0x00100000:0x00FFFFFF] (appClk domain)
+      -- GPU AXI-Lite Interfaces [0x00028000:0x00028FFF] (appClk domain)
       gpuReadMaster       : out AxiLiteReadMasterType;
       gpuReadSlave        : in  AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_DECERR_C;
       gpuWriteMaster      : out AxiLiteWriteMasterType;


### PR DESCRIPTION
### Description
- Added the mapping of axilite XBAR to gpuAsyncCore in AxiPcieReg.vhd

```vhdl
      GPU_INDEX_C     => (
         baseAddr     => x"0002_8000",
         addrBits     => 15,
```