### PR TITLE
Added gpu-enabled bit

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 
-Copyright (c) 2024, The Board of Trustees of the Leland Stanford Junior 
+Copyright (c) 2025, The Board of Trustees of the Leland Stanford Junior 
 University, through SLAC National Accelerator Laboratory (subject to receipt 
 of any required approvals from the U.S. Dept. of Energy). All rights reserved. 
 Redistribution and use in source and binary forms, with or without 

--- a/protocol/gpuAsync/rtl/AxiPcieGpuAsyncControl.vhd
+++ b/protocol/gpuAsync/rtl/AxiPcieGpuAsyncControl.vhd
@@ -32,6 +32,7 @@ entity AxiPcieGpuAsyncControl is
    generic (
       TPD_G            : time                  := 1 ns;
       MAX_BUFFERS_G    : integer range 1 to 16 := 4;
+      VERSION          : bool := false;
       DMA_AXI_CONFIG_G : AxiConfigType);
    port (
       -- AXI4-Lite Interfaces (axilClk domain)
@@ -111,6 +112,7 @@ architecture mapping of AxiPcieGpuAsyncControl is
       dmaRdDescRetAck   : sl;
       dynamicRouteMasks : Slv8Array(1 downto 0);
       dynamicRouteDests : Slv8Array(1 downto 0);
+      version           : sl;
    end record;
 
    constant REG_INIT_C : RegType := (
@@ -152,7 +154,8 @@ architecture mapping of AxiPcieGpuAsyncControl is
       dmaRdDescReq      => AXI_READ_DMA_DESC_REQ_INIT_C,
       dmaRdDescRetAck   => '0',
       dynamicRouteMasks => (0 => x"00", 1 => x"FF"),
-      dynamicRouteDests => (0 => x"00", 1 => x"FF"));
+      dynamicRouteDests => (0 => x"00", 1 => x"FF"),
+      version           =>  '0');
 
    signal r   : RegType := REG_INIT_C;
    signal rin : RegType;
@@ -214,6 +217,15 @@ begin
          v.axiReadErrorVal  := (others => '0');
       end if;
 
+      -- version 
+      if VERSION = true then
+         -- firmware is gpu-enabled
+         v.version := '0';
+      else 
+         -- if '1' firmware is NOT gpu-enabled
+         v.version := '1';
+      end if;
+
       -- Latency Counters
       for i in 0 to MAX_BUFFERS_G-1 loop
          if r.totLatencyEn(i) = '1' then
@@ -255,6 +267,7 @@ begin
       axiSlaveRegister (axilEp, x"02C", 8, v.dynamicRouteDests(0));
       axiSlaveRegister (axilEp, x"02C", 16, v.dynamicRouteMasks(1));
       axiSlaveRegister (axilEp, x"02C", 24, v.dynamicRouteDests(1));
+      axiSlaveRegisterR(axilEp, x"030", 0, r.version);
 
       for i in 0 to MAX_BUFFERS_G-1 loop
          axiSlaveRegister (axilEp, toSlv(256+i*16+0, 12), 0, v.remoteWriteAddrL(i));  -- 0x1x0 (x = 0,1,2,3....)

--- a/protocol/gpuAsync/rtl/AxiPcieGpuAsyncCore.vhd
+++ b/protocol/gpuAsync/rtl/AxiPcieGpuAsyncCore.vhd
@@ -33,7 +33,6 @@ entity AxiPcieGpuAsyncCore is
    generic (
       TPD_G             : time                  := 1 ns;
       MAX_BUFFERS_G     : integer range 1 to 16 := 4;
-      VERSION           : bool                  := true; 
       DMA_AXIS_CONFIG_G : AxiStreamConfigType);
    port (
       -- AXI4-Lite Interfaces (axilClk domain)
@@ -110,7 +109,6 @@ begin
       generic map (
          TPD_G            => TPD_G,
          MAX_BUFFERS_G    => MAX_BUFFERS_G,
-         VERSION          => VERSION,
          DMA_AXI_CONFIG_G => AXI_PCIE_CONFIG_C)
       port map (
          axilClk           => axilClk,

--- a/protocol/gpuAsync/rtl/AxiPcieGpuAsyncCore.vhd
+++ b/protocol/gpuAsync/rtl/AxiPcieGpuAsyncCore.vhd
@@ -33,6 +33,7 @@ entity AxiPcieGpuAsyncCore is
    generic (
       TPD_G             : time                  := 1 ns;
       MAX_BUFFERS_G     : integer range 1 to 16 := 4;
+      VERSION           : bool                  := true; 
       DMA_AXIS_CONFIG_G : AxiStreamConfigType);
    port (
       -- AXI4-Lite Interfaces (axilClk domain)
@@ -109,6 +110,7 @@ begin
       generic map (
          TPD_G            => TPD_G,
          MAX_BUFFERS_G    => MAX_BUFFERS_G,
+         VERSION          => VERSION,
          DMA_AXI_CONFIG_G => AXI_PCIE_CONFIG_C)
       port map (
          axilClk           => axilClk,


### PR DESCRIPTION
Added a register which is set to 0 when AxiPcieGpuAsyncCore.vhd (https://github.com/slaclab/axi-pcie-core/blob/main/protocol/gpuAsync/rtl/AxiPcieGpuAsyncCore.vhd) is added to the firmware.

It will be used to distinguish between gpu-enabled and non-gpu-enabled firmware.