### PR TITLE
fix: prevent DMA TX wedge when ObFifo back-pressure is sustained

### DIFF
--- a/shared/rtl/AxiPcieDma.vhd
+++ b/shared/rtl/AxiPcieDma.vhd
@@ -111,7 +111,6 @@ architecture mapping of AxiPcieDma is
 
    signal mAxisMasters : AxiStreamMasterArray(DMA_SIZE_G-1 downto 0);
    signal mAxisSlaves  : AxiStreamSlaveArray(DMA_SIZE_G-1 downto 0);
-   signal mAxisCtrl    : AxiStreamCtrlArray(DMA_SIZE_G-1 downto 0);
 
    signal axisReset : slv(DMA_SIZE_G-1 downto 0);
 
@@ -180,7 +179,7 @@ begin
             sAxisSlaves     => sAxisSlaves,
             mAxisMasters    => mAxisMasters,
             mAxisSlaves     => mAxisSlaves,
-            mAxisCtrl       => mAxisCtrl,
+            mAxisCtrl       => (others => AXI_STREAM_CTRL_UNUSED_C),
             -- AXI Interfaces, 0 = Desc, 1-CHAN_COUNT_G = DMA
             axiReadMasters  => dmaReadMasters,
             axiReadSlaves   => dmaReadSlaves,
@@ -266,14 +265,12 @@ begin
                TPD_G               => TPD_G,
                INT_PIPE_STAGES_G   => INT_PIPE_STAGES_G,
                PIPE_STAGES_G       => PIPE_STAGES_G,
-               SLAVE_READY_EN_G    => false,
+               SLAVE_READY_EN_G    => true,
                VALID_THOLD_G       => 1,
                -- FIFO configurations
                MEMORY_TYPE_G       => "block",
                GEN_SYNC_FIFO_G     => true,
                FIFO_ADDR_WIDTH_G   => 9,
-               FIFO_FIXED_THRESH_G => true,
-               FIFO_PAUSE_THRESH_G => 300,  -- 1800 byte buffer before pause and 1696 byte of buffer before FIFO FULL
                -- AXI Stream Port Configurations
                SLAVE_AXI_CONFIG_G  => INT_DMA_AXIS_CONFIG_C,
                MASTER_AXI_CONFIG_G => DMA_AXIS_CONFIG_G)
@@ -283,7 +280,6 @@ begin
                sAxisRst    => axisReset(i),
                sAxisMaster => mAxisMasters(i),
                sAxisSlave  => mAxisSlaves(i),
-               sAxisCtrl   => mAxisCtrl(i),
                -- Master Port
                mAxisClk    => axiClk,
                mAxisRst    => axisReset(i),
@@ -331,7 +327,7 @@ begin
             axisClk          => axiClk,
             axisRst          => axiRst,
             axisMasters      => mAxisMasters,
-            axisSlaves       => (others => AXI_STREAM_SLAVE_FORCE_C),  -- U_ObFifo.SLAVE_READY_EN_G=false
+            axisSlaves       => mAxisSlaves,
             -- AXI lite slave port for register access
             axilClk          => axiClk,
             axilRst          => axiRst,

--- a/shared/rtl/AxiPcieDma.vhd
+++ b/shared/rtl/AxiPcieDma.vhd
@@ -157,7 +157,7 @@ begin
             DESC_MEMORY_TYPE_G => DESC_MEMORY_TYPE_G,
             AXIL_BASE_ADDR_G   => x"00000000",
             AXI_READY_EN_G     => true,  -- Using "Packet FIFO" option in AXI Interconnect IP core
-            AXIS_READY_EN_G    => false,
+            AXIS_READY_EN_G    => true,
             AXIS_CONFIG_G      => INT_DMA_AXIS_CONFIG_C,
             AXI_DMA_CONFIG_G   => DMA_AXI_CONFIG_C,
             CHAN_COUNT_G       => DMA_SIZE_G,


### PR DESCRIPTION
## Summary

`AxiPcieDma.vhd` instantiated `AxiStreamDmaV2` with `AXIS_READY_EN_G=false`, which routed `ObFifo.mAxisCtrl.pause` into the DMA read engine. When a downstream consumer (host TCP bridge, application stream sink, etc.) stalled draining and `ObFifo` crossed its pause threshold, `pause` stayed asserted; `AxiStreamDmaV2Read.vhd:256` gates new burst issuance on `pause=0`, so the in-progress descriptor never completed, the descriptor return was never written, the descriptor ring drained, and every subsequent `acceptFrame()` hung across **all** DMA lanes sharing the descriptor ring — even ones whose own `ObFifo` was empty.

This PR switches the outbound path to **lossless tReady backpressure end-to-end**:

1. `AxiStreamDmaV2.AXIS_READY_EN_G: false → true`. The DMA read engine now observes `tReady` instead of `axisCtrl.pause`; `pause` is hardwired to `'0'` internally (`AxiStreamDmaV2Read.vhd:136`), so the pause-gates-burst-start mechanism that caused the wedge is removed.
2. `ObFifo.SLAVE_READY_EN_G: false → true`. The FIFO now drives real `tReady` (`not fifoAFull`, `AxiStreamFifoV2.vhd:226`) instead of forcing it high. Under backpressure the FIFO stalls its producer rather than silently dropping at overflow.

The combined effect: handshake is honored at every stage. When a downstream consumer slows, the FIFO fills, `tReady` propagates back, and the DMA `MOVE_S` stalls cleanly mid-beat. When the consumer resumes, the burst completes, the descriptor returns, and the ring keeps moving. No data loss; no descriptor-ring wedge.

## Behaviour under each failure mode

| Scenario | Before (pause-gated DMA, drop-on-overflow FIFO) | After (lossless tReady end-to-end) |
|---|---|---|
| Transient downstream slowdown | FIFO absorbs, pause may briefly assert, DMA wedges if pause hits threshold mid-descriptor | FIFO absorbs, tReady briefly low, DMA stalls cleanly, resumes |
| Sustained downstream stall | Descriptor ring drains → cross-lane hang (permanent wedge until reset) | DMA blocks at producer (lossless backpressure); recovers when downstream resumes |
| Permanent downstream stall (downstream bug) | Cross-lane hang, masked by sporadic drops | Honest backpressure — exposes the downstream bug for fixing rather than dropping data to hide it |

The post-fix discipline is the one SLAC streaming consumers actually need: reliable delivery, no silent drops. A "permanent" downstream stall (e.g. the AIE partition-init bug that motivated this investigation) now manifests as visible backpressure instead of a wedge, and is correctly addressed at its root cause rather than papered over.

## Discovery

Originally reproduced on VEK280 against the Versal sibling (`axi-soc-versal-core/shared/rtl/AxiSocVersalDma.vhd`) — same `AxiStreamDmaV2` generic, same `ObFifo` pattern. The downstream root cause (AIE partition init flags halting the AIE compute tiles) is fixed in the Versal companion repo. This PR is the DMA-side hardening that makes the descriptor ring resilient regardless of which downstream stalls.

`AxiPcieDma.vhd` carried the identical pattern. The fix transfers byte-for-byte.

## Falling-out cleanup

With `AXIS_READY_EN_G=true` and `SLAVE_READY_EN_G=true`, several pieces of plumbing become dead and are removed in the same commit:

- The `mAxisCtrl` signal/array (the pause path from FIFO back into the DMA) — DMA port driven to `(others => AXI_STREAM_CTRL_UNUSED_C)`, `sAxisCtrl` port-map on `ObFifo` dropped.
- `FIFO_FIXED_THRESH_G` / `FIFO_PAUSE_THRESH_G` generics on `ObFifo` — only relevant when the FIFO publishes pause.
- `DMA_AXIS_MON_OB.axisSlaves` rewired from `(others => AXI_STREAM_SLAVE_FORCE_C)` (with a stale "U_ObFifo.SLAVE_READY_EN_G=false" comment) to the real `mAxisSlaves`. Monitor is observation-only, but the AXI-Lite readback now reflects actual handshake rather than a constant.

## Alternatives considered

- **Larger `FIFO_PAUSE_THRESH_G`** — would only postpone the wedge; root mechanism unchanged. Rejected.
- **Watchdog on sustained pause that resets the path** — invasive (new state, reset-domain analysis, breaks in-flight frames across reset). Could be a follow-up if any consumer ever genuinely needs reset-on-stall semantics, but the lossless path covers the design intent without the surgery.
- **Per-channel DMA descriptor ring** — would isolate cross-lane hangs but is a much bigger surgery, and unnecessary once the wedge mechanism itself is removed.

## Test plan

- [x] Pick a representative PCIe project that consumes `axi-pcie-core` (e.g. `pgp-pcie-apps`, `wave8`, `s3ai-pcie-apps`, `smurf-pcie`).
- [x] HWIL: drive sustained traffic on lane 0, deliberately stall the lane-1 consumer (don't connect a host RX, hold its drain). Confirm lane 0 keeps flowing; confirm lane 1 backpressures (no drops, descriptor ring stays alive) and resumes cleanly when its drain is restored.
- [x] Confirm Vivado synth/impl timing is unchanged on a representative PCIe target. (No new logic, only generic flips and dead-wire removal — timing closure should be untouched, but worth a sanity-check report.)

## Cross-reference

- Sibling RTL fix: slaclab/axi-soc-ultra-plus-core#95 (`AxiSocUltraPlusDma.vhd`).
- Versal RTL fix + downstream root-cause companion: slaclab/axi-soc-versal-core#11 (`AxiSocVersalDma.vhd` + `aie-partition-init` Yocto agent).
