### PR TITLE
BittWare XUP-VV8: FW-driven PCA9555 init + AxiPcieCore transceiverClass refactor

### DIFF
--- a/hardware/BittWareXupVv8/core/BittWareXupVv8Core.vhd
+++ b/hardware/BittWareXupVv8/core/BittWareXupVv8Core.vhd
@@ -116,7 +116,13 @@ architecture mapping of BittWareXupVv8Core is
 
    constant GPIO_DEVICE_MAP_C : I2cAxiLiteDevArray(0 to 0) := (
       0              => MakeI2cAxiLiteDevType(
-         i2cAddress  => "0100000",      -- PCA9555
+         -- QSFP-GPIO PCA9555 at I2C address 7-bit 0x21 (8-bit write 0x42)
+         -- per XUP-VV8 Hardware Reference Guide rev 19 (2025-05-07) section 4.9.2.
+         -- Prior value "0100000" (7-bit 0x20) targeted the OCU-GPIO PCA9555,
+         -- which left QSFP_RST_L and QSFP_LP undriven from FW. Confirmed via
+         -- software read-back of PCA9555 Input Port (PRSNT_L bits all 1 with
+         -- modules inserted) before this change.
+         i2cAddress  => "0100001",      -- PCA9555 (QSFP-GPIO)
          dataSize    => 8,              -- in units of bits
          addrSize    => 8,              -- in units of bits
          endianness  => '0',            -- Little endian
@@ -147,10 +153,14 @@ architecture mapping of BittWareXupVv8Core is
    signal intPipObMaster : AxiWriteMasterType := AXI_WRITE_MASTER_INIT_C;
    signal intPipObSlave  : AxiWriteSlaveType  := AXI_WRITE_SLAVE_FORCE_C;
 
-   signal mI2cReadMasters  : AxiLiteReadMasterArray(1 downto 0);
-   signal mI2cReadSlaves   : AxiLiteReadSlaveArray(1 downto 0)  := (others => AXI_LITE_READ_SLAVE_EMPTY_DECERR_C);
-   signal mI2cWriteMasters : AxiLiteWriteMasterArray(1 downto 0);
-   signal mI2cWriteSlaves  : AxiLiteWriteSlaveArray(1 downto 0) := (others => AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
+   -- U_XbarMI2cMux slave ports:
+   --   (0) = CPU (AxiPcieReg)
+   --   (1) = U_QsfpCdrDisable (idle when QSFP_CDR_DISABLE_G=false)
+   --   (2) = U_BittWareXupVv8QsfpInit (one-shot PCA9555 init at startup)
+   signal mI2cReadMasters  : AxiLiteReadMasterArray(2 downto 0)  := (others => AXI_LITE_READ_MASTER_INIT_C);
+   signal mI2cReadSlaves   : AxiLiteReadSlaveArray(2 downto 0)   := (others => AXI_LITE_READ_SLAVE_EMPTY_DECERR_C);
+   signal mI2cWriteMasters : AxiLiteWriteMasterArray(2 downto 0) := (others => AXI_LITE_WRITE_MASTER_INIT_C);
+   signal mI2cWriteSlaves  : AxiLiteWriteSlaveArray(2 downto 0)  := (others => AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
 
    signal i2cReadMaster  : AxiLiteReadMasterType;
    signal i2cReadSlave   : AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_DECERR_C;
@@ -255,7 +265,6 @@ begin
       intPipIbSlave <= pipIbSlave;
 
       QSFP_CDR_DISABLE : if (QSFP_CDR_DISABLE_G) generate
-
          U_QsfpCdrDisable : entity surf.QsfpCdrDisable
             generic map (
                TPD_G             => TPD_G,
@@ -270,36 +279,38 @@ begin
                mAxilReadSlave   => mI2cReadSlaves(1),
                mAxilWriteMaster => mI2cWriteMasters(1),
                mAxilWriteSlave  => mI2cWriteSlaves(1));
-
-         U_XbarMI2cMux : entity surf.AxiLiteCrossbar
-            generic map (
-               TPD_G              => TPD_G,
-               NUM_SLAVE_SLOTS_G  => 2,
-               NUM_MASTER_SLOTS_G => 1,
-               MASTERS_CONFIG_G   => XBAR_MI2C_CONFIG_C)
-            port map (
-               axiClk              => sysClock,
-               axiClkRst           => sysReset,
-               sAxiWriteMasters    => mI2cWriteMasters,
-               sAxiWriteSlaves     => mI2cWriteSlaves,
-               sAxiReadMasters     => mI2cReadMasters,
-               sAxiReadSlaves      => mI2cReadSlaves,
-               mAxiWriteMasters(0) => i2cWriteMaster,
-               mAxiWriteSlaves(0)  => i2cWriteSlave,
-               mAxiReadMasters(0)  => i2cReadMaster,
-               mAxiReadSlaves(0)   => i2cReadSlave);
-
       end generate;
 
-      BYP_QSFP_CDR_DISABLE : if (not QSFP_CDR_DISABLE_G) generate
+      U_BittWareXupVv8QsfpInit : entity axi_pcie_core.BittWareXupVv8QsfpInit
+         generic map (
+            TPD_G           => TPD_G,
+            PCA9555_ADDR_G  => x"0007_3000",
+            AXIL_CLK_FREQ_G => DMA_CLK_FREQ_C)
+         port map (
+            axilClk          => sysClock,
+            axilRst          => sysReset,
+            mAxilReadMaster  => mI2cReadMasters(2),
+            mAxilReadSlave   => mI2cReadSlaves(2),
+            mAxilWriteMaster => mI2cWriteMasters(2),
+            mAxilWriteSlave  => mI2cWriteSlaves(2));
 
-         i2cWriteMaster     <= mI2cWriteMasters(0);
-         mI2cWriteSlaves(0) <= i2cWriteSlave;
-
-         i2cReadMaster     <= mI2cReadMasters(0);
-         mI2cReadSlaves(0) <= i2cReadSlave;
-
-      end generate;
+      U_XbarMI2cMux : entity surf.AxiLiteCrossbar
+         generic map (
+            TPD_G              => TPD_G,
+            NUM_SLAVE_SLOTS_G  => 3,
+            NUM_MASTER_SLOTS_G => 1,
+            MASTERS_CONFIG_G   => XBAR_MI2C_CONFIG_C)
+         port map (
+            axiClk              => sysClock,
+            axiClkRst           => sysReset,
+            sAxiWriteMasters    => mI2cWriteMasters,
+            sAxiWriteSlaves     => mI2cWriteSlaves,
+            sAxiReadMasters     => mI2cReadMasters,
+            sAxiReadSlaves      => mI2cReadSlaves,
+            mAxiWriteMasters(0) => i2cWriteMaster,
+            mAxiWriteSlaves(0)  => i2cWriteSlave,
+            mAxiReadMasters(0)  => i2cReadMaster,
+            mAxiReadSlaves(0)   => i2cReadSlave);
 
       U_XbarI2cMux : entity surf.AxiLiteCrossbarI2cMux
          generic map (

--- a/hardware/BittWareXupVv8/core/BittWareXupVv8QsfpInit.vhd
+++ b/hardware/BittWareXupVv8/core/BittWareXupVv8QsfpInit.vhd
@@ -1,0 +1,186 @@
+-------------------------------------------------------------------------------
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: One-shot AXI-Lite initializer for the QSFP-GPIO PCA9555 on the
+--              BittWare XUP-VV8. At reset release, writes the Output, Polarity
+--              Inversion, and Configuration byte registers of the PCA9555 to
+--              put the four QSFP-DD slots into a known state:
+--                 OP  (regs 0x02/0x03) = 0x88  -- LP=0, RST_L=1 for each nibble
+--                 POL (regs 0x04/0x05) = 0x00  -- no inversion
+--                 CFG (regs 0x06/0x07) = 0x33  -- PRSNT_L/INT_L=input,
+--                                              -- LP/RST_L=output
+--
+--              Output Port is written before Configuration so LP[i] never
+--              briefly drives '1' (low-power asserted) during the moment the
+--              direction bits flip from input (PCA9555 power-up default) to
+--              output. The PCA9555 OP register defaults to 0xFF on power-up.
+-------------------------------------------------------------------------------
+-- This file is part of 'axi-pcie-core'.
+-- It is subject to the license terms in the LICENSE.txt file found in the
+-- top-level directory of this distribution and at:
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+-- No part of 'axi-pcie-core', including this file,
+-- may be copied, modified, propagated, or distributed except according to
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_arith.all;
+use ieee.std_logic_unsigned.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
+
+entity BittWareXupVv8QsfpInit is
+   generic (
+      TPD_G           : time             := 1 ns;
+      -- AXI-Lite base address of the QSFP-GPIO PCA9555 device.
+      PCA9555_ADDR_G  : slv(31 downto 0) := x"0007_3000";
+      AXIL_CLK_FREQ_G : real             := 250.0E+6);
+   port (
+      -- AXI-Lite Master Interface (axilClk domain)
+      axilClk          : in  sl;
+      axilRst          : in  sl;
+      mAxilReadMaster  : out AxiLiteReadMasterType;
+      mAxilReadSlave   : in  AxiLiteReadSlaveType;
+      mAxilWriteMaster : out AxiLiteWriteMasterType;
+      mAxilWriteSlave  : in  AxiLiteWriteSlaveType);
+end BittWareXupVv8QsfpInit;
+
+architecture rtl of BittWareXupVv8QsfpInit is
+
+   -- 1 ms settling delay before the first I2C transaction.
+   constant SETTLE_DELAY_C : positive := getTimeRatio(AXIL_CLK_FREQ_G, 1000.0);
+
+   -- PCA9555 byte-register offsets, AXI-Lite-word-aligned (reg << 2).
+   constant ADDR_OP0_C  : slv(31 downto 0) := x"0000_0008";  -- Output Port 0
+   constant ADDR_OP1_C  : slv(31 downto 0) := x"0000_000C";  -- Output Port 1
+   constant ADDR_POL0_C : slv(31 downto 0) := x"0000_0010";  -- Polarity Inv 0
+   constant ADDR_POL1_C : slv(31 downto 0) := x"0000_0014";  -- Polarity Inv 1
+   constant ADDR_CFG0_C : slv(31 downto 0) := x"0000_0018";  -- Configuration 0
+   constant ADDR_CFG1_C : slv(31 downto 0) := x"0000_001C";  -- Configuration 1
+
+   type StateType is (
+      REQ_S,
+      ACK_S,
+      DONE_S);
+
+   type RegType is record
+      cnt   : natural range 0 to 5;
+      timer : natural range 0 to SETTLE_DELAY_C;
+      req   : AxiLiteReqType;
+      state : StateType;
+   end record;
+
+   constant REG_INIT_C : RegType := (
+      cnt   => 0,
+      timer => SETTLE_DELAY_C,
+      req   => AXI_LITE_REQ_INIT_C,
+      state => REQ_S);
+
+   signal r   : RegType := REG_INIT_C;
+   signal rin : RegType;
+
+   signal ack : AxiLiteAckType;
+
+begin
+
+   U_AxiLiteMaster : entity surf.AxiLiteMaster
+      generic map (
+         TPD_G => TPD_G)
+      port map (
+         req             => r.req,
+         ack             => ack,
+         axilClk         => axilClk,
+         axilRst         => axilRst,
+         axilWriteMaster => mAxilWriteMaster,
+         axilWriteSlave  => mAxilWriteSlave,
+         axilReadMaster  => mAxilReadMaster,
+         axilReadSlave   => mAxilReadSlave);
+
+   ---------------------
+   -- AXI Lite Interface
+   ---------------------
+   comb : process (ack, axilRst, r) is
+      variable v : RegType;
+   begin
+      v := r;
+
+      -- Decrement the settling timer
+      if (r.timer /= 0) then
+         v.timer := r.timer - 1;
+      end if;
+
+      -- State Machine
+      case (r.state) is
+         ----------------------------------------------------------------------
+         when REQ_S =>
+            if (ack.done = '0') and (r.timer = 0) then
+
+               v.req.request := '1';
+               v.req.rnw     := '0';        -- write
+
+               case r.cnt is
+                  when 0 =>  -- OP_PORT_0 = 0x88  (LP=0, RST_L=1; write OP before CFG)
+                     v.req.address := PCA9555_ADDR_G + ADDR_OP0_C;
+                     v.req.wrData  := x"0000_0088";
+                  when 1 =>  -- OP_PORT_1 = 0x88
+                     v.req.address := PCA9555_ADDR_G + ADDR_OP1_C;
+                     v.req.wrData  := x"0000_0088";
+                  when 2 =>  -- POL_PORT_0 = 0x00  (no inversion)
+                     v.req.address := PCA9555_ADDR_G + ADDR_POL0_C;
+                     v.req.wrData  := x"0000_0000";
+                  when 3 =>  -- POL_PORT_1 = 0x00
+                     v.req.address := PCA9555_ADDR_G + ADDR_POL1_C;
+                     v.req.wrData  := x"0000_0000";
+                  when 4 =>  -- CFG_PORT_0 = 0x33  (PRSNT_L/INT_L=in, LP/RST_L=out)
+                     v.req.address := PCA9555_ADDR_G + ADDR_CFG0_C;
+                     v.req.wrData  := x"0000_0033";
+                  when others =>  -- 5: CFG_PORT_1 = 0x33
+                     v.req.address := PCA9555_ADDR_G + ADDR_CFG1_C;
+                     v.req.wrData  := x"0000_0033";
+               end case;
+
+               v.state := ACK_S;
+            end if;
+         ----------------------------------------------------------------------
+         when ACK_S =>
+            if (ack.done = '1') then
+
+               v.req.request := '0';
+
+               if (r.cnt = 5) then
+                  v.state := DONE_S;
+               else
+                  v.cnt   := r.cnt + 1;
+                  v.state := REQ_S;
+               end if;
+
+            end if;
+         ----------------------------------------------------------------------
+         when DONE_S =>
+            -- One-shot init complete; remain here until next axilRst.
+            v.timer := 0;
+      ----------------------------------------------------------------------
+      end case;
+
+      -- Reset
+      if (axilRst = '1') then
+         v := REG_INIT_C;
+      end if;
+
+      -- Register the variable for next clock cycle
+      rin <= v;
+
+   end process comb;
+
+   seq : process (axilClk) is
+   begin
+      if (rising_edge(axilClk)) then
+         r <= rin after TPD_G;
+      end if;
+   end process seq;
+
+end rtl;

--- a/python/axipcie/_AxiPcieCore.py
+++ b/python/axipcie/_AxiPcieCore.py
@@ -21,6 +21,29 @@ import axipcie as pcie
 import click
 import time
 
+
+# Default per-slot transceiver class for boards with configurable slots.
+# The list length sets the required transceiverClass length when overridden.
+_DEFAULT_TRANSCEIVERS = {
+    'BittWareXupVv8Vu9p':  [xceiver.Qsfp]*4,
+    'BittWareXupVv8Vu13p': [xceiver.Qsfp]*4,
+    'SlacPgpCardG4':       [xceiver.Qsfp]*2, # third cage is a fixed SFP, not configurable
+    'XilinxKcu1500':       [xceiver.Qsfp]*2,
+    'XilinxAlveoU200':     [xceiver.Qsfp]*2,
+    'XilinxAlveoU250':     [xceiver.Qsfp]*2,
+    'XilinxAlveoU280':     [xceiver.Qsfp]*2,
+    'XilinxAlveoU55c':     [xceiver.Qsfp]*2,
+    'XilinxVariumC1100':   [xceiver.Qsfp]*2,
+}
+
+# String label -> transceiver class.
+_TRANSCEIVER_DISPATCH = {
+    'QSFP':    xceiver.Qsfp,
+    'SFP':     xceiver.Sfp,
+    'QSFP-DD': xceiver.QsfpDd,
+}
+
+
 class AxiPcieCore(pr.Device):
     """This class maps to axi-pcie-core/shared/rtl/AxiPcieReg.vhd"""
     def __init__(self,
@@ -28,12 +51,39 @@ class AxiPcieCore(pr.Device):
                  useBpi      = False,
                  useGpu      = False,
                  useSpi      = False,
-                 useSfp      = [False, False],
+                 transceiverClass = [None],
                  numDmaLanes = 1,
                  boardType   = None,
                  extended    = False,
                  sim         = False,
                  **kwargs):
+
+        # Resolve per-slot transceiver classes BEFORE super().__init__() so a
+        # ValueError on bad input does not leave a partially-constructed
+        # pyrogue Device holding leaked worker threads.
+        # Per-entry None in transceiverClass skips that slot (no device added).
+        slotClasses = None
+        if boardType in _DEFAULT_TRANSCEIVERS:
+            defaults = _DEFAULT_TRANSCEIVERS[boardType]
+            if transceiverClass == [None]:
+                slotClasses = list(defaults)
+            else:
+                if len(transceiverClass) != len(defaults):
+                    raise ValueError(
+                        f'transceiverClass must be a list of {len(defaults)} '
+                        f'entries for {boardType}; got len={len(transceiverClass)}')
+                slotClasses = []
+                for c in transceiverClass:
+                    if c is None:
+                        slotClasses.append(None)
+                        continue
+                    try:
+                        slotClasses.append(_TRANSCEIVER_DISPATCH[str(c).upper()])
+                    except KeyError as exc:
+                        raise ValueError(
+                            f'transceiverClass entry {exc} not in '
+                            f'{{QSFP, SFP, QSFP-DD}}') from exc
+
         super().__init__(description=description, **kwargs)
 
         self.numDmaLanes = numDmaLanes
@@ -124,39 +174,33 @@ class AxiPcieCore(pr.Device):
                         enabled = False, # enabled=False because I2C are slow transactions and might "log jam" register transaction pipeline
                     ))
 
-                    if len(useSfp) != 4:
-                        useSfp = [False for _ in range(4)]
-
-                    for i in range(4):
-                        if not useSfp[i]:
-                            self.add(xceiver.Qsfp(
-                                name    = f'Qsfp[{i}]',
-                                offset  = i*0x1000+0x74000,
-                                memBase = self.AxilBridge.proxy,
-                                enabled = False, # enabled=False because I2C are slow transactions and might "log jam" register transaction pipeline
-                            ))
-                        else:
-                            self.add(xceiver.Sfp(
-                                name    = f'Qsfp[{i}]',
-                                offset  = i*0x1000+0x74000,
-                                memBase = self.AxilBridge.proxy,
-                                enabled = False, # enabled=False because I2C are slow transactions and might "log jam" register transaction pipeline
-                            ))
+                    for i, cls in enumerate(slotClasses):
+                        if cls is None:
+                            continue
+                        self.add(cls(
+                            name    = f'{cls.__name__}[{i}]',
+                            offset  = i*0x1000+0x74000,
+                            memBase = self.AxilBridge.proxy,
+                            enabled = False, # enabled=False because I2C are slow transactions and might "log jam" register transaction pipeline
+                        ))
 
                 elif (boardType == 'SlacPgpCardG4'):
 
                     XIL_DEVICE_G = 'ULTRASCALE'
 
-                    for i in range(2):
-                        self.add(xceiver.Qsfp(
-                            name    = f'Qsfp[{i}]',
+                    for i, cls in enumerate(slotClasses):
+                        if cls is None:
+                            continue
+                        self.add(cls(
+                            name    = f'{cls.__name__}[{i}]',
                             offset  = i*0x1000+0x70000,
                             memBase = self.AxilBridge.proxy,
                             enabled = False, # enabled=False because I2C are slow transactions and might "log jam" register transaction pipeline
                         ))
 
+                    # Slot 2 is a fixed SFP cage (physical hardware, not configurable).
                     self.add(xceiver.Sfp(
-                        name        = 'Sfp',
+                        name        = 'Sfp[2]',
                         offset      = 0x72000,
                         memBase     = self.AxilBridge.proxy,
                         enabled     = False, # enabled=False because I2C are slow transactions and might "log jam" register transaction pipeline
@@ -173,44 +217,31 @@ class AxiPcieCore(pr.Device):
                 elif (boardType == 'XilinxKcu1500'):
 
                     XIL_DEVICE_G = 'ULTRASCALE'
-                    qsfpOffset = [0x74_000,0x71_000]
+                    qsfpOffset = [0x74_000, 0x71_000]
 
-
-                    for i in range(2):
-                        if not useSfp[i]:
-                            self.add(xceiver.Qsfp(
-                                name    = f'Qsfp[{i}]',
-                                offset  = qsfpOffset[i],
-                                memBase = self.AxilBridge.proxy,
-                                enabled = False, # enabled=False because I2C are slow transactions and might "log jam" register transaction pipeline
-                            ))
-                        else:
-                            self.add(xceiver.Sfp(
-                                name    = f'Sfp[{i}]',
-                                offset  = qsfpOffset[i],
-                                memBase = self.AxilBridge.proxy,
-                                enabled = False, # enabled=False because I2C are slow transactions and might "log jam" register transaction pipeline
-                            ))
+                    for i, cls in enumerate(slotClasses):
+                        if cls is None:
+                            continue
+                        self.add(cls(
+                            name    = f'{cls.__name__}[{i}]',
+                            offset  = qsfpOffset[i],
+                            memBase = self.AxilBridge.proxy,
+                            enabled = False, # enabled=False because I2C are slow transactions and might "log jam" register transaction pipeline
+                        ))
 
                 elif (boardType == 'XilinxAlveoU200') or (boardType == 'XilinxAlveoU250') or (boardType == 'XilinxAlveoU280'):
 
                     XIL_DEVICE_G = 'ULTRASCALE_PLUS'
 
-                    for i in range(2):
-                        if not useSfp[i]:
-                            self.add(xceiver.Qsfp(
-                                name    = f'Qsfp[{i}]',
-                                offset  = i*0x1000+0x70000,
-                                memBase = self.AxilBridge.proxy,
-                                enabled = False, # enabled=False because I2C are slow transactions and might "log jam" register transaction pipeline
-                            ))
-                        else:
-                            self.add(xceiver.Sfp(
-                                name    = f'Qsfp[{i}]',
-                                offset  = i*0x1000+0x70000,
-                                memBase = self.AxilBridge.proxy,
-                                enabled = False, # enabled=False because I2C are slow transactions and might "log jam" register transaction pipeline
-                            ))
+                    for i, cls in enumerate(slotClasses):
+                        if cls is None:
+                            continue
+                        self.add(cls(
+                            name    = f'{cls.__name__}[{i}]',
+                            offset  = i*0x1000+0x70000,
+                            memBase = self.AxilBridge.proxy,
+                            enabled = False, # enabled=False because I2C are slow transactions and might "log jam" register transaction pipeline
+                        ))
 
                     self.add(silabs.Si570(
                         name = 'Si570',
@@ -238,21 +269,15 @@ class AxiPcieCore(pr.Device):
                         numCages   = 2,
                     ))
 
-                    for i in range(2):
-                        if not useSfp[i]:
-                            self.add(xceiver.Qsfp(
-                                name    = f'Qsfp[{i}]',
-                                offset  = qsfpOffset[i],
-                                memBase = self.CmsBridge.proxy,
-                                enabled = False, # enabled=False because I2C are slow transactions and might "log jam" register transaction pipeline
-                            ))
-                        else:
-                            self.add(xceiver.Sfp(
-                                name    = f'Sfp[{i}]',
-                                offset  = qsfpOffset[i],
-                                memBase = self.CmsBridge.proxy,
-                                enabled = False, # enabled=False because I2C are slow transactions and might "log jam" register transaction pipeline
-                            ))
+                    for i, cls in enumerate(slotClasses):
+                        if cls is None:
+                            continue
+                        self.add(cls(
+                            name    = f'{cls.__name__}[{i}]',
+                            offset  = qsfpOffset[i],
+                            memBase = self.CmsBridge.proxy,
+                            enabled = False, # enabled=False because I2C are slow transactions and might "log jam" register transaction pipeline
+                        ))
 
                 elif (boardType == 'XilinxKcu105'):
                     XIL_DEVICE_G = 'ULTRASCALE'

--- a/python/axipcie/_BittWareXupVv8QsfpGpio.py
+++ b/python/axipcie/_BittWareXupVv8QsfpGpio.py
@@ -14,79 +14,130 @@ class BittWareXupVv8QsfpGpio(pr.Device):
     def __init__(self,**kwargs):
         super().__init__(**kwargs)
 
-        # Map QSFP signals
-        nameList = [
-            'QSFP_PRSNT_L[0]', # IO0_0
-            'QSFP_INT_L[0]',   # IO0_1
-            'QSFP_LP[0]',      # IO0_2
-            'QSFP_RST_L[0]',   # IO0_3
-            'QSFP_PRSNT_L[1]', # IO0_4
-            'QSFP_INT_L[1]',   # IO0_5
-            'QSFP_LP[1]',      # IO0_6
-            'QSFP_RST_L[1]',   # IO0_7
-            'QSFP_PRSNT_L[2]', # IO1_0
-            'QSFP_INT_L[2]',   # IO1_1
-            'QSFP_LP[2]',      # IO1_2
-            'QSFP_RST_L[2]',   # IO1_3
-            'QSFP_PRSNT_L[3]', # IO1_4
-            'QSFP_INT_L[3]',   # IO1_5
-            'QSFP_LP[3]',      # IO1_6
-            'QSFP_RST_L[3]',   # IO1_7
-        ]
+        # PCA9555 Input/Output port byte registers are each mapped to their own
+        # AXI-Lite word (low byte significant). Per the XUP-VV8 schematic, each
+        # nibble carries one QSFP slot:
+        #   Port 0 (IP @ 0x00, OP @ 0x08) bits [3:0]=slot 0, bits [7:4]=slot 1
+        #   Port 1 (IP @ 0x04, OP @ 0x0C) bits [3:0]=slot 2, bits [7:4]=slot 3
+        # Within each nibble: bit0=PRSNT_L, bit1=INT_L, bit2=LP, bit3=RST_L.
+        # Each 4-bit RemoteVariable below composes [slot0, slot1, slot2, slot3].
 
-        # The PCA9555 has two 8-bit ports (Port 0 and Port 1)
-        for i in range(2):  # Port 0 and Port 1
-            for j in range(8):  # Each has 8 bits
-                idx = 8*i + j
+        self.add(pr.RemoteVariable(
+            name        = 'QSFP_PRSNT_L',
+            description = 'Per-slot QSFP module presence (0=present, 1=absent), bit[i]=slot[i]',
+            offset      = [0x00, 0x00, 0x04, 0x04],
+            bitOffset   = [0, 4, 0, 4],
+            bitSize     = [1, 1, 1, 1],
+            mode        = 'RO',
+        ))
 
-                # Input Port registers (read-only)
-                self.add(pr.RemoteVariable(
-                    name        = f'IP_{nameList[idx]}',
-                    description = 'Input Port registers',
-                    offset      = (0x00 + i) << 2,
-                    bitOffset   = j,
-                    bitSize     = 1,
-                    mode        = 'RO',
-                ))
+        self.add(pr.RemoteVariable(
+            name        = 'QSFP_INT_L',
+            description = 'Per-slot QSFP interrupt (0=active, 1=inactive), bit[i]=slot[i]',
+            offset      = [0x00, 0x00, 0x04, 0x04],
+            bitOffset   = [1, 5, 1, 5],
+            bitSize     = [1, 1, 1, 1],
+            mode        = 'RO',
+        ))
 
-        # The PCA9555 has two 8-bit ports (Port 0 and Port 1)
-        for i in range(2):  # Port 0 and Port 1
-            for j in range(8):  # Each has 8 bits
-                idx = 8*i + j
-                # Output Port registers (read/write)
-                self.add(pr.RemoteVariable(
-                    name        = f'OP_{nameList[idx]}',
-                    description = 'Output Port registers',
-                    offset      = (0x02 + i) << 2,
-                    bitOffset   = j,
-                    bitSize     = 1,
-                    mode        = 'RW',
-                ))
+        self.add(pr.RemoteVariable(
+            name        = 'QSFP_LP',
+            description = 'Per-slot QSFP low-power mode (1=low-power, 0=normal), bit[i]=slot[i]',
+            offset      = [0x08, 0x08, 0x0C, 0x0C],
+            bitOffset   = [2, 6, 2, 6],
+            bitSize     = [1, 1, 1, 1],
+            mode        = 'RW',
+        ))
 
-        # The PCA9555 has two 8-bit ports (Port 0 and Port 1)
-        for i in range(2):  # Port 0 and Port 1
-            for j in range(8):  # Each has 8 bits
-                idx = 8*i + j
-                # Polarity Inversion registers (read/write)
-                self.add(pr.RemoteVariable(
-                    name        = f'POL_{nameList[idx]}',
-                    description = 'Polarity Inversion registers',
-                    offset      = (0x04 + i) << 2,
-                    bitOffset   = j,
-                    bitSize     = 1,
-                    mode        = 'RW',
-                ))
+        self.add(pr.RemoteVariable(
+            name        = 'QSFP_RST_L',
+            description = 'Per-slot QSFP reset (0=reset asserted, 1=de-asserted), bit[i]=slot[i]',
+            offset      = [0x08, 0x08, 0x0C, 0x0C],
+            bitOffset   = [3, 7, 3, 7],
+            bitSize     = [1, 1, 1, 1],
+            mode        = 'RW',
+        ))
 
-        # The PCA9555 has two 8-bit ports (Port 0 and Port 1)
-        for i in range(2):  # Port 0 and Port 1
-            for j in range(8):  # Each has 8 bits
-                idx = 8*i + j
-                # Configuration registers (read/write)
-                self.add(pr.RemoteVariable(
-                    name        = f'CFG_{nameList[idx]}',
-                    description = 'I/O Configuration registers',
-                    offset      = (0x06 + i) << 2,
-                    bitOffset   = j,
-                    bitSize     = 1,
-                    mode        = 'RW',
-                ))
+        # PCA9555 Polarity Inversion (regs 0x04/0x05 @ AXI 0x10/0x14).
+        # Expected value: 0 for all bits (no inversion).
+        self.add(pr.RemoteVariable(
+            name        = 'POL_QSFP_PRSNT_L',
+            description = 'Polarity inversion for PRSNT_L (expect 0), bit[i]=slot[i]',
+            offset      = [0x10, 0x10, 0x14, 0x14],
+            bitOffset   = [0, 4, 0, 4],
+            bitSize     = [1, 1, 1, 1],
+            mode        = 'RW',
+            hidden      = True,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'POL_QSFP_INT_L',
+            description = 'Polarity inversion for INT_L (expect 0), bit[i]=slot[i]',
+            offset      = [0x10, 0x10, 0x14, 0x14],
+            bitOffset   = [1, 5, 1, 5],
+            bitSize     = [1, 1, 1, 1],
+            mode        = 'RW',
+            hidden      = True,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'POL_QSFP_LP',
+            description = 'Polarity inversion for LP (expect 0), bit[i]=slot[i]',
+            offset      = [0x10, 0x10, 0x14, 0x14],
+            bitOffset   = [2, 6, 2, 6],
+            bitSize     = [1, 1, 1, 1],
+            mode        = 'RW',
+            hidden      = True,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'POL_QSFP_RST_L',
+            description = 'Polarity inversion for RST_L (expect 0), bit[i]=slot[i]',
+            offset      = [0x10, 0x10, 0x14, 0x14],
+            bitOffset   = [3, 7, 3, 7],
+            bitSize     = [1, 1, 1, 1],
+            mode        = 'RW',
+            hidden      = True,
+        ))
+
+        # PCA9555 I/O Configuration (regs 0x06/0x07 @ AXI 0x18/0x1C).
+        # 1=input, 0=output. Expected: PRSNT_L/INT_L=1 (input), LP/RST_L=0 (output).
+        self.add(pr.RemoteVariable(
+            name        = 'CFG_QSFP_PRSNT_L',
+            description = 'Direction config for PRSNT_L (1=input, expect 1), bit[i]=slot[i]',
+            offset      = [0x18, 0x18, 0x1C, 0x1C],
+            bitOffset   = [0, 4, 0, 4],
+            bitSize     = [1, 1, 1, 1],
+            mode        = 'RW',
+            hidden      = True,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'CFG_QSFP_INT_L',
+            description = 'Direction config for INT_L (1=input, expect 1), bit[i]=slot[i]',
+            offset      = [0x18, 0x18, 0x1C, 0x1C],
+            bitOffset   = [1, 5, 1, 5],
+            bitSize     = [1, 1, 1, 1],
+            mode        = 'RW',
+            hidden      = True,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'CFG_QSFP_LP',
+            description = 'Direction config for LP (0=output, expect 0), bit[i]=slot[i]',
+            offset      = [0x18, 0x18, 0x1C, 0x1C],
+            bitOffset   = [2, 6, 2, 6],
+            bitSize     = [1, 1, 1, 1],
+            mode        = 'RW',
+            hidden      = True,
+        ))
+
+        self.add(pr.RemoteVariable(
+            name        = 'CFG_QSFP_RST_L',
+            description = 'Direction config for RST_L (0=output, expect 0), bit[i]=slot[i]',
+            offset      = [0x18, 0x18, 0x1C, 0x1C],
+            bitOffset   = [3, 7, 3, 7],
+            bitSize     = [1, 1, 1, 1],
+            mode        = 'RW',
+            hidden      = True,
+        ))


### PR DESCRIPTION
## Summary

Stabilizes the BittWare XUP-VV8 QSFP-DD / I2C bring-up path and refactors the per-slot transceiver-class API exposed by `AxiPcieCore`. Folds together the `useSfp` deprecation, the PCA9555 I2C address fix, and migration of the PCA9555 init sequence from SW (`_start()` on `QsfpGpio`) to a dedicated FW module that runs once at reset release.

Base: `pre-release` &nbsp;·&nbsp; Head: `bittware-qsfp-i2c-dev`

## Changes

### `hardware/BittWareXupVv8/core/BittWareXupVv8QsfpInit.vhd` (new)

One-shot AXI-Lite state machine that initializes the QSFP-GPIO PCA9555 at `axilRst` release. Modeled on `lcls2-pgp-fw-lib/TimingPhyInit.vhd` and `surf/QsfpCdrDisable.vhd`; uses `surf.AxiLiteMaster` with a 1 ms settling delay before the first write, then parks in `DONE_S`.

| Step | PCA9555 reg | AXI offset | Value | Purpose |
|------|-------------|-----------|-------|---------|
| 1 | OP_PORT_0  | `0x0007_3008` | `0x88` | LP=0, RST_L=1 (slots 0,1) — OP before CFG |
| 2 | OP_PORT_1  | `0x0007_300C` | `0x88` | LP=0, RST_L=1 (slots 2,3) |
| 3 | POL_PORT_0 | `0x0007_3010` | `0x00` | No polarity inversion |
| 4 | POL_PORT_1 | `0x0007_3014` | `0x00` | No polarity inversion |
| 5 | CFG_PORT_0 | `0x0007_3018` | `0x33` | PRSNT_L/INT_L = input, LP/RST_L = output |
| 6 | CFG_PORT_1 | `0x0007_301C` | `0x33` | Same for slots 2,3 |

OP is written before CFG so `LP[i]` never briefly drives `'1'` (low-power asserted) during the moment direction bits flip from input (PCA9555 power-up default) to output.

### `hardware/BittWareXupVv8/core/BittWareXupVv8Core.vhd`

- **PCA9555 I2C address fix**: 7-bit `"0100000"` (`0x20`, wrong: OCU-GPIO) → `"0100001"` (`0x21`, correct: QSFP-GPIO) per XUP-VV8 Hardware Reference Guide rev 19 §4.9.2. Bench-confirmed PRSNT_L bits flipped from all-1 to all-0 with modules inserted.
- **`U_XbarMI2cMux` moved outside the `QSFP_CDR_DISABLE` generate** and grown from 2 → 3 slave ports:
  - `(0)` CPU via `AxiPcieReg` (unchanged)
  - `(1)` `U_QsfpCdrDisable` (still gated by `QSFP_CDR_DISABLE_G`; idle slot defaults to `AXI_LITE_*_MASTER_INIT_C`)
  - `(2)` `U_BittWareXupVv8QsfpInit` (unconditional)
- `BYP_QSFP_CDR_DISABLE` generate dropped (the crossbar now exists in both branches).

### `python/axipcie/_AxiPcieCore.py`

- **Drop `useSfp` parameter.** `transceiverClass` (default `[None]`) now drives per-slot form factor for every board with configurable cages: BittWare, KCU1500, AlveoU200/U250/U280, AlveoU55c/VariumC1100, and SlacPgpCardG4.
- New module-level `_DEFAULT_TRANSCEIVERS` table; list length defines the required override length and per-board defaults (all `Qsfp` today).
- `transceiverClass=[None]` → use defaults; otherwise length-checked and dispatched through `_TRANSCEIVER_DISPATCH` (`'QSFP'` / `'SFP'` / `'QSFP-DD'`).
- Per-entry `None` in an override list **skips** that slot (no device added at all).
- Slot device names derive from the class (`cls.__name__`): `Qsfp[i]`, `Sfp[i]`, `QsfpDd[i]`.
- `SlacPgpCardG4`'s third cage is a fixed SFP at offset `0x72000`, renamed to `Sfp[2]` so it never collides with user-selected `Sfp[0]` / `Sfp[1]`.
- Validation runs **before** `super().__init__()` so bad input never leaks pyrogue worker threads.

### `python/axipcie/_BittWareXupVv8QsfpGpio.py`

- Replaced 64 individual 1-bit `RemoteVariable`s with **12 grouped 4-bit RVs** using pyrogue's list-form `offset` / `bitOffset` / `bitSize` (same pattern as `surf/xilinx/_Gtxe2Channel.py`). Each variable composes bits as `[slot0, slot1, slot2, slot3]` across the PCA9555 Port 0 (slots 0/1) and Port 1 (slots 2/3) byte registers.
- **Active RW signals** (visible in the PyDM tree): `QSFP_PRSNT_L`, `QSFP_INT_L`, `QSFP_LP`, `QSFP_RST_L`.
- **RW debug** (hidden from the default GUI tree): `POL_QSFP_*` and `CFG_QSFP_*` so polarity-inversion and I/O-direction registers stay inspectable for hardware debug without cluttering the tree.
- Removed `_writePca9555Reg()` and `_start()` — FW now owns the init sequence (`time` and `rim` imports dropped too).

## Companion-repo callers

In `pgp-pcie-apps`, `software/scripts/LoopbackTesting.py` and `software/scripts/QsfpI2cSweep.py` now default `xcvr_list = [None]` (was `None`) so they match the new sentinel.

## CI

`compileall -f python/` and `flake8 --count python/` are clean.
