### PR TITLE
docs: fix tutorial + workflow + reference pages to match real build experience

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install Sphinx + Furo
+      - name: Install Sphinx + sphinx_rtd_theme
         run: |
           python -m pip install --upgrade pip
           pip install -r docs/requirements.txt

--- a/docs/explanation/board_support.rst
+++ b/docs/explanation/board_support.rst
@@ -47,8 +47,8 @@ The build system chains from the downstream project inward through four levels:
 1. The downstream project's top-level ``ruckus.tcl`` sources
    ``hardware/<BoardName>/ruckus.tcl`` via ``loadRuckusTcl``.
 2. The board ``ruckus.tcl`` sources ``shared/ruckus.tcl`` as its first action.
-3. ``shared/ruckus.tcl`` calls ``SubmoduleCheck`` to enforce ruckus v4.24.2 and
-   surf v2.71.0, verifies Vivado version ≥ 2020.1, then loads all of ``shared/rtl/``
+3. ``shared/ruckus.tcl`` calls ``SubmoduleCheck`` to enforce ruckus ≥ v4.24.2 and
+   surf ≥ v2.71.0, verifies Vivado version ≥ 2020.1, then loads all of ``shared/rtl/``
    and ``shared/ip/`` into the ``axi_pcie_core`` VHDL library.
 4. The board ``ruckus.tcl`` loads its own ``rtl/`` sources, the PCIe PHY ``.dcp``,
    the ``.xdc`` constraints, and — conditionally — the ``ddr/`` or ``hbm/`` subtree

--- a/docs/explanation/overview.rst
+++ b/docs/explanation/overview.rst
@@ -40,14 +40,17 @@ It does not cover:
 Relationship to ruckus and surf
 -------------------------------
 
-``ruckus`` is the TCL build framework that drives Vivado project assembly, pinned at
-version v4.24.2 (enforced in ``shared/ruckus.tcl``).  Each supported board ships a
+``ruckus`` is the TCL build framework that drives Vivado project assembly.  The minimum
+version is v4.24.2, enforced in ``shared/ruckus.tcl`` via ``SubmoduleCheck``; downstream
+projects are free to track a newer ruckus revision.  Each supported board ships a
 ``ruckus.tcl`` that a downstream project sources via ``loadRuckusTcl``, pulling in all
 board-specific RTL, IP, and constraints without any manual Vivado project setup.
 
-``surf`` is the SLAC FPGA RTL common library pinned at v2.71.0.  It supplies the
-primitives that every file under ``shared/rtl/`` depends on: ``AxiLitePkg``,
-``AxiStreamPkg``, ``AxiStreamDmaV2``, synchronisation primitives, and peripheral device
-drivers.  Both submodule pins are enforced at build time by the ``SubmoduleCheck`` call
-in ``shared/ruckus.tcl``, so a downstream project built against a mismatched ``surf`` or
-``ruckus`` revision receives a hard error rather than a silent ABI mismatch.
+``surf`` is the SLAC FPGA RTL common library; the minimum version is v2.71.0 (same
+enforcement mechanism as ruckus).  It supplies the primitives that every file under
+``shared/rtl/`` depends on: ``AxiLitePkg``, ``AxiStreamPkg``, ``AxiStreamDmaV2``,
+synchronisation primitives, and peripheral device drivers.  Both submodule version locks
+are enforced at build time, so a downstream project built against a mismatched ``surf`` or
+``ruckus`` revision receives a hard error rather than a silent ABI mismatch.  Set the
+environment variable ``OVERRIDE_SUBMODULE_LOCKS=1`` before invoking ``make`` to bypass
+the check during development.

--- a/docs/how-to/add_new_board.rst
+++ b/docs/how-to/add_new_board.rst
@@ -40,7 +40,13 @@ layout:
 
 Boards without on-board memory omit the ``ddr/`` or ``hbm/`` subtree.  Some
 boards with multiple PCIe lane configurations split the PCIe subtree into
-``pcie-<variant>/`` directories (e.g., ``pcie-3x16/``, ``pcie-4x8/``).
+``pcie-<variant>/`` directories (e.g., ``pcie-3x16/``, ``pcie-4x8/``); see
+``hardware/XilinxAlveoU280/pcie-3x16/`` and ``hardware/XilinxVariumC1100/pcie-4x8/``
+for two worked examples.  When a board uses a PCIe-variant subdirectory, the
+top-level ``<NewBoard>Core.vhd`` lives at
+``hardware/<NewBoard>/pcie-<variant>/rtl/<NewBoard>Core.vhd`` rather than
+``hardware/<NewBoard>/rtl/<NewBoard>Core.vhd``; the ``ruckus.tcl`` chain selects
+the variant subdirectory based on the downstream project's target.
 
 Reference: :repo:`hardware/XilinxKcu1500/` shows the full directory tree for a
 board with PCIe, DDR4, and a PCIe-extended optional variant.

--- a/docs/how-to/use_pyrogue.rst
+++ b/docs/how-to/use_pyrogue.rst
@@ -20,8 +20,8 @@ Linux device-node path:
 
     import axipcie as pcie
 
-    # Real hardware: opens rogue.hardware.axi.AxiMemMap to /dev/data_dev0
-    memMap = pcie.createAxiPcieMemMap('/dev/data_dev0')
+    # Real hardware: opens rogue.hardware.axi.AxiMemMap to /dev/datadev_0
+    memMap = pcie.createAxiPcieMemMap('/dev/datadev_0')
 
 The function signature is:
 
@@ -44,7 +44,7 @@ opens DMA stream channels for one or more (lane, destination) pairs:
 
     # Open lane 0, destinations 0 and 1
     dmaStreams = pcie.createAxiPcieDmaStreams(
-        '/dev/data_dev0',
+        '/dev/datadev_0',
         streamMap={0: [0, 1]},
     )
 
@@ -74,7 +74,7 @@ BAR0 internally and instantiates ``AxiPcieCore`` at the top of the device tree:
 
     import axipcie as pcie
 
-    root = pcie.AxiPcieRoot(dev='/dev/data_dev0', name='PCIeDevice')
+    root = pcie.AxiPcieRoot(dev='/dev/datadev_0', name='PCIeDevice')
     root.start()
 
 For production projects that need to wire DMA streams alongside the register
@@ -85,9 +85,9 @@ tree, build a custom ``pr.Root`` subclass using the helpers above:
     import pyrogue as pr
     import axipcie as pcie
 
-    memMap = pcie.createAxiPcieMemMap('/dev/data_dev0')
+    memMap = pcie.createAxiPcieMemMap('/dev/datadev_0')
     dmaStreams = pcie.createAxiPcieDmaStreams(
-        '/dev/data_dev0',
+        '/dev/datadev_0',
         streamMap={0: [0, 1]},
     )
 

--- a/docs/reference/supported_boards.rst
+++ b/docs/reference/supported_boards.rst
@@ -129,7 +129,10 @@ Notes
 
 * Vivado version requirements: Vivado 2020.1 or later is required for all boards except
   ``XilinxAlveoU55c`` and ``XilinxVariumC1100``, which require Vivado 2024.2 or later
-  due to their CMS block-design and HBM IP dependencies.
+  due to their CMS block-design and HBM IP dependencies.  These are the *minimum*
+  versions enforced by ``shared/ruckus.tcl`` via ``VersionCheck``; at SLAC the current
+  tested production toolchain is Vivado 2025.2 (see
+  :doc:`/tutorial/first_build`).
 
 * See :doc:`/explanation/board_support` for the per-board directory layout
   (``hardware/<Board>/ruckus.tcl`` chain, PCIe variant subdirectories, DDR/HBM optional

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 sphinx==8.1.3
-sphinx-rtd-theme
+sphinx-rtd-theme==3.0.2
 sphinx-copybutton==0.5.2

--- a/docs/tutorial/first_build.rst
+++ b/docs/tutorial/first_build.rst
@@ -7,9 +7,12 @@ This tutorial walks you through building a real PCIe bitstream for the
 
 .. note::
 
-   **Vivado 2024.2 or later is required.**  The ``XilinxVariumC1100`` target
-   uses the CMS block design and HBM2 IP, both of which require Vivado 2024.2+.
-   See :doc:`/reference/supported_boards` for a full list of per-board Vivado
+   **Vivado 2024.2 or later is required for the XilinxVariumC1100 target**
+   because the board's CMS block design and HBM2 IP are only available from
+   2024.2 onwards.  At SLAC the current production toolchain is **Vivado
+   2025.2** (see the SLAC sourcing step below); the build flow in this
+   tutorial has been verified end-to-end on 2025.2.  See
+   :doc:`/reference/supported_boards` for a full list of per-board Vivado
    version requirements.
 
 The board is a Gen4x8 PCIe card with HBM2 on-board memory.  The end artifact
@@ -20,15 +23,26 @@ loading or hardware bring-up.
 Prerequisites
 -------------
 
-Before you begin, ensure the following are installed and available on your
-``PATH``:
+You need the following on your workstation before you begin:
 
-- **git** 2.x with **git-lfs** installed and initialized (required for
-  ``.dcp``, ``.mcs``, and ``.bit`` assets tracked in LFS)
-- **Vivado 2024.2** or later (the ``vivado`` executable must be on your
-  ``PATH`` or sourced via the Vivado settings script)
-- **JTAG cable** and Vivado Hardware Manager (required for loading the
-  bitstream to the board after the build; not needed for the build itself)
+- **git** 2.x with **git-lfs** installed and initialized — ``axi-pcie-core``
+  uses LFS for pre-compiled IP checkpoints (``.dcp``), so a clone without
+  active LFS leaves placeholder files in place of binary IP and the build
+  will fail.
+- **Vivado 2024.2 or later** with the ``vivado`` executable on your
+  ``PATH``.  At SLAC S3DF the standard activation step is::
+
+     source /sdf/group/faders/tools/xilinx/<version>/Vivado/<version>/settings64.sh
+
+  For example for 2025.2::
+
+     source /sdf/group/faders/tools/xilinx/2025.2/Vivado/2025.2/settings64.sh
+
+  Outside SLAC, run your site's equivalent ``settings64.sh``, or invoke
+  ``vivado`` from a shell where ``which vivado`` already resolves.
+
+A JTAG cable and Vivado Hardware Manager are *not* required to build the
+bitstream — only to load it on a physical board afterwards.
 
 Verify git-lfs is active before cloning:
 
@@ -61,8 +75,27 @@ Initialise Submodules
 
    git submodule update --init --recursive
 
-This downloads the pinned versions of all submodules.  On a first clone the
-step takes several minutes and transfers several hundred megabytes.
+This downloads the pinned versions of all submodules and pulls LFS-tracked
+binary IP checkpoints.  On a first clone the step takes several minutes and
+transfers approximately 1 GB.
+
+Source the Vivado Environment
+------------------------------
+
+Make sure ``vivado`` is on your ``PATH`` (and licence is reachable).  At
+SLAC S3DF:
+
+.. code-block:: bash
+
+   source /sdf/group/faders/tools/xilinx/2025.2/Vivado/2025.2/settings64.sh
+
+You can confirm with:
+
+.. code-block:: bash
+
+   which vivado
+   vivado -version | head -1
+   # Expected:  Vivado v2025.2 (64-bit)
 
 Navigate to the Build Target
 -----------------------------
@@ -90,8 +123,60 @@ manual block-design configuration is needed.  See
 :doc:`/explanation/architecture` for a description of the shared RTL modules
 that ``axi-pcie-core`` contributes to this build.
 
-A successful full build takes approximately two to four hours depending on
-your workstation.
+A successful full build typically takes several hours on a modern
+workstation.  Use ``make`` again later — incremental dependencies in
+ruckus.tcl will skip steps that have not changed.
+
+Where the Build Runs
+~~~~~~~~~~~~~~~~~~~~
+
+ruckus writes the Vivado project and per-run artefacts under:
+
+.. code-block:: text
+
+   firmware/build/XilinxVariumC1100DmaLoopback/
+
+This is the working build tree (Vivado ``.xpr``, synth/impl runs,
+checkpoints).  At SLAC the ruckus build location can be redirected to a
+faster local scratch path via ``$TOP_DIR/build`` symlink convention; out of
+the box it resolves to ``firmware/build/<TargetName>/``.
+
+The final shipping artefacts are copied to a separate directory under the
+target itself — see `Build Artefacts`_ below.
+
+Expected Critical Warnings
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The XilinxVariumC1100 build emits two non-fatal ``CRITICAL_WARNING`` lines
+that are expected and safe to ignore:
+
+* ``[Designutils 20-1280] Could not find module
+  'XilinxVariumC1100PciePhyGen4x8_pcie4c_ip'. The XDC file ...
+  _late.xdc will not be read for any cell of this module.``
+
+  The PCIe PHY is delivered as a pre-compiled ``.dcp`` checkpoint, so its
+  inner module is not visible to the late XDC pass.  Vivado applies the
+  constraints when the DCP is linked in.
+
+* ``[Project 1-498] One or more constraints failed evaluation while
+  reading constraint file [.../pcie-4x8/xdc/XilinxVariumC1100Timing.xdc]
+  and the design contains unresolved black boxes.``
+
+  Same root cause as above — the PHY is a black box at this point of
+  elaboration; Vivado re-reads and applies these timing constraints
+  post-synthesis.
+
+Other Useful Targets
+~~~~~~~~~~~~~~~~~~~~
+
+The Makefile inherits standard ruckus targets:
+
+.. code-block:: bash
+
+   make gui      # open the Vivado project in the GUI for debugging
+   make bit      # build only the .bit file
+   make prom     # build the .bit + .mcs PROM image (same as default)
+   make clean    # remove the build/ tree
 
 Build Artefacts
 ---------------
@@ -102,12 +187,61 @@ On a successful build, output files are placed under:
 
    firmware/targets/XilinxVariumC1100/XilinxVariumC1100DmaLoopback/images/
 
-The directory will contain:
+By default (``GEN_BIT_IMAGE=1``, ``GEN_MCS_IMAGE=1``, gzip flags off) the
+directory will contain a ``.bit`` and a ``.mcs`` whose basename is
+ruckus's ``IMAGENAME``:
 
 .. code-block:: text
 
-   XilinxVariumC1100DmaLoopback-<version>.bit   # Vivado bitstream
-   XilinxVariumC1100DmaLoopback-<version>.mcs   # MCS programming file
+   XilinxVariumC1100DmaLoopback-0x03030000-20260521094121-ruckman-b94c4a7.bit   # ~21 MB
+   XilinxVariumC1100DmaLoopback-0x03030000-20260521094121-ruckman-b94c4a7.mcs   # ~57 MB, SPIx4 PROM
+
+ruckus defines ``IMAGENAME`` in
+``ruckus/system_shared.mk`` as
+``$(PROJECT)-$(PRJ_VERSION)-$(BUILD_TIME)-$(USER)-$(GIT_HASH_SHORT)``,
+so the filename embeds the full build provenance:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 16 18 44
+
+   * - Field
+     - Make variable
+     - Example
+     - Source
+   * - target name
+     - ``$(PROJECT)``
+     - ``XilinxVariumC1100DmaLoopback``
+     - target directory name
+   * - firmware version
+     - ``$(PRJ_VERSION)``
+     - ``0x03030000``
+     - downstream project's ``shared_config.mk``
+   * - build timestamp
+     - ``$(BUILD_TIME)``
+     - ``20260521094121``
+     - ``date +%Y%m%d%H%M%S`` at build start; can be overridden via env var
+   * - user
+     - ``$(USER)``
+     - ``ruckman``
+     - the Unix user that ran ``make``
+   * - git hash
+     - ``$(GIT_HASH_SHORT)``
+     - ``b94c4a7``
+     - ``git rev-parse --short HEAD`` of the downstream project
+
+If the working tree is dirty (``git update-index --refresh`` reports
+unstaged changes), the trailing git-hash segment is replaced with the
+literal string ``dirty`` so an inadvertent uncommitted build is
+immediately recognisable from the filename.
+
+For partial-reconfiguration flows (``RECONFIG_STATIC_HASH != 0``), an
+additional ``_<RECONFIG_STATIC_HASH>`` suffix is appended after the
+git hash.
+
+Set ``GEN_BIT_IMAGE_GZIP=1`` and/or ``GEN_MCS_IMAGE_GZIP=1`` in the
+environment before invoking ``make`` to also produce gzipped copies
+(``.bit.gz``, ``.mcs.gz``).
 
 Use the ``.bit`` file to program the board over JTAG with Vivado Hardware
 Manager.  Use the ``.mcs`` file to program the SPI configuration PROM for
@@ -120,3 +254,8 @@ Next Steps
   see :doc:`/how-to/integrate_as_submodule`.
 - For a complete list of supported boards and their Vivado version
   requirements, see :doc:`/reference/supported_boards`.
+- For the in-hardware PRBS test variant of the same XilinxVariumC1100
+  flow (a second target that pulls in ``common/PrbsTester`` and the board
+  ``ddr`` subtree), see ``firmware/targets/XilinxVariumC1100/XilinxVariumC1100PrbsTester/``
+  in ``pgp-pcie-apps``.  The build invocation is identical (``cd`` into the
+  target directory and run ``make``).


### PR DESCRIPTION
## Summary

Fixes concrete gaps found by running the tutorial end-to-end on S3DF with Vivado 2025.2 (`XilinxVariumC1100DmaLoopback` + `PrbsTester` via `slaclab/pgp-pcie-apps`). Docs-only — no RTL, submodule, or Python changes.

- Pin `sphinx-rtd-theme==3.0.2` and fix the workflow step label ("Sphinx + Furo" → rtd).
- Correct `/dev/data_dev0` → `/dev/datadev_0` in `use_pyrogue` (matches `pyrogue_api.rst` and `aes-stream-drivers`).
- Rewrite `first_build` to cover `settings64.sh`, build-tree layout, expected C1100 CRITICAL_WARNINGs, extra `make` targets, gzip env hooks, and the PrbsTester cross-ref.
- Reword surf/ruckus pins as `>=` minimums (enforced by `SubmoduleCheck`), document `OVERRIDE_SUBMODULE_LOCKS=1`, and note the `pcie-<variant>/` subdir pattern.

## Test plan

- [x] `Build documentation (strict)` CI job stays green
- [x] Maintainer spot-checks tutorial commands
