### PR TITLE
Add IRQ_TYPE_G generic to AxiPcieUltrascalePlusIrqFsm (INTX/MSI/MSIX)

### DIFF
--- a/shared/rtl/AxiPcieUltrascalePlusIrqFsm.vhd
+++ b/shared/rtl/AxiPcieUltrascalePlusIrqFsm.vhd
@@ -2,6 +2,18 @@
 -- Company    : SLAC National Accelerator Laboratory
 -------------------------------------------------------------------------------
 -- Description: AXI PCIe Ultrascale+ IRQ FSM
+--
+-- Drives the Xilinx XDMA usr_irq_req / usr_irq_ack handshake. Per PG195 the
+-- ack semantics differ by interrupt mode:
+--   INTX        : ack on req rising edge (Assert_INTA TLP sent)
+--                 AND ack on req falling edge (Deassert_INTA TLP sent)
+--                 -> 6-state two-ack handshake (default).
+--   MSI / MSIX  : ack on req rising edge (MSI/MSI-X memory write completed),
+--                 NO ack on falling edge (message-based, no deassert TLP)
+--                 -> 4-state single-ack handshake.
+-- Select via IRQ_TYPE_G ("INTX" | "MSI" | "MSIX"). MSI and MSIX behave
+-- identically on the firmware side; the difference lives in the PCIe IP
+-- XCI configuration and the host-side capability discovery.
 -------------------------------------------------------------------------------
 -- This file is part of 'axi-pcie-core'.
 -- It is subject to the license terms in the LICENSE.txt file found in the
@@ -22,7 +34,8 @@ use surf.StdRtlPkg.all;
 
 entity AxiPcieUltrascalePlusIrqFsm is
    generic (
-      TPD_G : time := 1 ns);
+      TPD_G      : time   := 1 ns;
+      IRQ_TYPE_G : string := "INTX");  -- "INTX" | "MSI" | "MSIX"
    port (
       -- Clock and Reset
       clk       : in  sl;
@@ -34,6 +47,10 @@ entity AxiPcieUltrascalePlusIrqFsm is
 end AxiPcieUltrascalePlusIrqFsm;
 
 architecture rtl of AxiPcieUltrascalePlusIrqFsm is
+
+   -- Synthesis-time mode select. INTX uses the legacy two-ack handshake;
+   -- MSI / MSIX use the single-ack message-based handshake.
+   constant INTX_C : boolean := (IRQ_TYPE_G = "INTX");
 
    type StateType is (
       IDLE_S,
@@ -57,6 +74,10 @@ architecture rtl of AxiPcieUltrascalePlusIrqFsm is
    signal rin : RegType;
 
 begin
+
+   assert (IRQ_TYPE_G = "INTX") or (IRQ_TYPE_G = "MSI") or (IRQ_TYPE_G = "MSIX")
+      report "AxiPcieUltrascalePlusIrqFsm: IRQ_TYPE_G must be ""INTX"", ""MSI"", or ""MSIX"" (got: " & IRQ_TYPE_G & ")"
+      severity failure;
 
    comb : process (dmaIrq, r, rstL, usrIrqAck) is
       variable v : RegType;
@@ -88,7 +109,13 @@ begin
             if (dmaIrq = '0') or (r.irqTimer = 250000000) then
                v.irqTimer  := (others => '0');
                v.usrIrqReq := '0';
-               v.state     := CLR_S;
+               if INTX_C then
+                  -- Legacy INTx: wait for the Deassert_INTA ack pair.
+                  v.state := CLR_S;
+               else
+                  -- MSI / MSIX: no deassert message, no second ack.
+                  v.state := IDLE_S;
+               end if;
             end if;
          ----------------------------------------------------------------------
          when CLR_S =>


### PR DESCRIPTION
## Summary

Adds an `IRQ_TYPE_G` generic to `shared/rtl/AxiPcieUltrascalePlusIrqFsm.vhd` so the IRQ FSM can drive the correct `usr_irq_req`/`usr_irq_ack` handshake for legacy INTx **or** message-based (MSI/MSI-X) interrupts on the Xilinx XDMA/AXI-Bridge core.

## Why

Per PG195 the `usr_irq_ack` handshake differs by interrupt mode:

| Mode | Ack on req rising edge | Ack on req falling edge |
|------|------------------------|-------------------------|
| Legacy INTx | yes (Assert_INTA TLP) | yes (Deassert_INTA TLP) |
| MSI / MSI-X | yes (message write done) | **no** (message-based, no deassert) |

The existing 6-state FSM waits for the second (deassert) ack, which is correct for INTx but hangs forever in MSI/MSI-X mode because that ack never arrives.

## Change

- `IRQ_TYPE_G : string := "INTX"` — values `"INTX"` | `"MSI"` | `"MSIX"`.
  - `"INTX"` (default): unchanged 6-state two-ack FSM. **All existing instantiations are bit-for-bit identical — no regression** (every current board wrapper instantiates without the generic and gets the default).
  - `"MSI"`/`"MSIX"`: 4-state single-ack FSM that returns to `IDLE` after deasserting `usr_irq_req` instead of waiting for a nonexistent second ack. MSI and MSI-X share the same firmware-side handshake.
- Synthesis-time elaboration assert rejects invalid `IRQ_TYPE_G` values.

## Scope

FSM only. Board-wrapper opt-in (passing `IRQ_TYPE_G => "MSI"`/`"MSIX"`) and any per-board PCIe IP reconfiguration are intentionally **not** included here.