### PR TITLE
RDMA Enable Readbacks

### DIFF
--- a/protocol/gpuAsync/rtl/AxiPcieGpuAsyncControl.vhd
+++ b/protocol/gpuAsync/rtl/AxiPcieGpuAsyncControl.vhd
@@ -210,9 +210,9 @@ architecture rtl of AxiPcieGpuAsyncControl is
       writeSlaves             : AxiLiteWriteSlaveArray(1 downto 0);
       -- DEMUX Control
       axisDeMuxSelect         : sl;
-      -- Readbacks for writeEnable/readEnable
-      readRdmaEnable          : sl;
-      writeRdmaEnable         : sl;
+      -- Indicates read or write RDMA active
+      readActive              : sl;
+      writeActive             : sl;
    end record;
 
    constant REG_INIT_C : RegType := (
@@ -294,9 +294,9 @@ architecture rtl of AxiPcieGpuAsyncControl is
       writeSlaves             => (others => AXI_LITE_WRITE_SLAVE_INIT_C),
       -- DEMUX Control
       axisDeMuxSelect         => DEFAULT_DEMUX_SEL_G,
-      -- Readbacks for write/read Enable
-      readRdmaEnable          => '0',
-      writeRdmaEnable         => '0');
+      -- Indicates read/write RDMA active
+      readActive              => '0',
+      writeActive             => '0');
 
    signal r   : RegType := REG_INIT_C;
    signal rin : RegType;
@@ -547,8 +547,8 @@ begin
       axiSlaveRegisterR(axilEp(0), x"40", 0, r.maxReadBuffer);
 
       -- Readbacks for write/read enable. Software should wait on these before freeing buffers.
-      axiSlaveRegisterR(axilEp(0), x"44", 0, r.writeRdmaEnable);
-      axiSlaveRegisterR(axilEp(0), x"44", 1, r.readRdmaEnable);
+      axiSlaveRegisterR(axilEp(0), x"44", 0, r.writeActive);
+      axiSlaveRegisterR(axilEp(0), x"44", 1, r.readActive);
 
       axiSlaveRegister (axilEp(0), x"60", 0, v.remoteWriteMaxSize);
 
@@ -877,7 +877,7 @@ begin
 
       -- Propagate readback when in idle state
       if (r.rxState = IDLE_S) then
-         v.writeRdmaEnable := r.writeEnable;
+         v.writeActive := r.writeEnable;
       end if;
 
       --------------------------------------------------------------------------------------------
@@ -1024,7 +1024,7 @@ begin
 
       -- Propagate readback when in idle state
       if (r.txState = IDLE_S) then
-         v.readRdmaEnable := r.readEnable;
+         v.readActive := r.readEnable;
       end if;
 
       -- Section A3.4.3 Data read and write structure: Write strobes - Narrow transfers

--- a/protocol/gpuAsync/rtl/AxiPcieGpuAsyncControl.vhd
+++ b/protocol/gpuAsync/rtl/AxiPcieGpuAsyncControl.vhd
@@ -539,7 +539,7 @@ begin
 
       -- Offset 0x2C: Legacy dynamicRouteMasks/dynamicRouteDests
 
-      axiSlaveRegisterR(axilEp(0), x"30", 0, toSlv(4, 8));  -- version number, >= 1 if gpu enabled
+      axiSlaveRegisterR(axilEp(0), x"30", 0, toSlv(5, 8));  -- version number, >= 1 if gpu enabled
       axiSlaveRegisterR(axilEp(0), x"34", 0, r.axiWriteTimeoutErrorCnt);
       axiSlaveRegister (axilEp(0), x"38", 0, v.axisDeMuxSelect);  -- 1: GPU path, 0: CPU path
 

--- a/protocol/gpuAsync/rtl/AxiPcieGpuAsyncControl.vhd
+++ b/protocol/gpuAsync/rtl/AxiPcieGpuAsyncControl.vhd
@@ -748,6 +748,9 @@ begin
       case r.rxState is
          ----------------------------------------------------------------------
          when IDLE_S =>
+            -- Update the active flag
+            v.writeActive := r.writeEnable;
+
             -- Check if there is a DMA request
             if (dmaWrDescReq.valid = '1') then
 
@@ -875,11 +878,6 @@ begin
          v.nextWriteIdx := (others => '0');
       end if;
 
-      -- Propagate readback when in idle state
-      if (r.rxState = IDLE_S) then
-         v.writeActive := r.writeEnable;
-      end if;
-
       --------------------------------------------------------------------------------------------
       -- Read/TX State Machine
       --------------------------------------------------------------------------------------------
@@ -901,6 +899,9 @@ begin
       case r.txState is
          ----------------------------------------------------------------------
          when IDLE_S =>
+            -- Update the active flag
+            v.readActive := r.readEnable;
+
             -- Check if read enabled and new buffer ready for DMA read transaction
             if (r.readEnable = '1') and (r.readReqList(conv_integer(r.nextReadIdx)) = '1') and (r.dmaRdDescReq.valid = '0') then
 
@@ -1020,11 +1021,6 @@ begin
          -- Reset the buffer index and the free list
          v.nextReadIdx := (others => '0');
          v.readReqList := (others => '0');
-      end if;
-
-      -- Propagate readback when in idle state
-      if (r.txState = IDLE_S) then
-         v.readActive := r.readEnable;
       end if;
 
       -- Section A3.4.3 Data read and write structure: Write strobes - Narrow transfers

--- a/protocol/gpuAsync/rtl/AxiPcieGpuAsyncControl.vhd
+++ b/protocol/gpuAsync/rtl/AxiPcieGpuAsyncControl.vhd
@@ -210,6 +210,9 @@ architecture rtl of AxiPcieGpuAsyncControl is
       writeSlaves             : AxiLiteWriteSlaveArray(1 downto 0);
       -- DEMUX Control
       axisDeMuxSelect         : sl;
+      -- Readbacks for writeEnable/readEnable
+      readRdmaEnable          : sl;
+      writeRdmaEnable         : sl;
    end record;
 
    constant REG_INIT_C : RegType := (
@@ -290,7 +293,10 @@ architecture rtl of AxiPcieGpuAsyncControl is
       readSlaves              => (others => AXI_LITE_READ_SLAVE_INIT_C),
       writeSlaves             => (others => AXI_LITE_WRITE_SLAVE_INIT_C),
       -- DEMUX Control
-      axisDeMuxSelect         => DEFAULT_DEMUX_SEL_G);
+      axisDeMuxSelect         => DEFAULT_DEMUX_SEL_G,
+      -- Readbacks for write/read Enable
+      readRdmaEnable          => '0',
+      writeRdmaEnable         => '0');
 
    signal r   : RegType := REG_INIT_C;
    signal rin : RegType;
@@ -539,6 +545,10 @@ begin
 
       axiSlaveRegisterR(axilEp(0), x"3C", 0, r.minWriteBuffer);
       axiSlaveRegisterR(axilEp(0), x"40", 0, r.maxReadBuffer);
+
+      -- Readbacks for write/read enable. Software should wait on these before freeing buffers.
+      axiSlaveRegisterR(axilEp(0), x"44", 0, r.writeRdmaEnable);
+      axiSlaveRegisterR(axilEp(0), x"44", 1, r.readRdmaEnable);
 
       axiSlaveRegister (axilEp(0), x"60", 0, v.remoteWriteMaxSize);
 
@@ -865,6 +875,11 @@ begin
          v.nextWriteIdx := (others => '0');
       end if;
 
+      -- Propagate readback when in idle state
+      if (r.rxState = IDLE_S) then
+         v.writeRdmaEnable := r.writeEnable;
+      end if;
+
       --------------------------------------------------------------------------------------------
       -- Read/TX State Machine
       --------------------------------------------------------------------------------------------
@@ -1005,6 +1020,11 @@ begin
          -- Reset the buffer index and the free list
          v.nextReadIdx := (others => '0');
          v.readReqList := (others => '0');
+      end if;
+
+      -- Propagate readback when in idle state
+      if (r.txState = IDLE_S) then
+         v.readRdmaEnable := r.readEnable;
       end if;
 
       -- Section A3.4.3 Data read and write structure: Write strobes - Narrow transfers


### PR DESCRIPTION
## Description

Adds a readback register for the readEnable/writeEnable bits.

## Details

In the driver, we need a way to detect when DMA transfers are in progress when unmapping p2p pages. If we unmap the p2p pages while a transfer is in progress, undefined behavior will occur. In some cases, this can even lead to an NVIDIA driver crash, which seems to happen consistently with multiple FPGAs RDMA-ing to one GPU. These readbacks are only propagated when the state machine is in its idle state.

I have bumped the GpuAsyncCore version to 5 because we need to add a hacky workaround in the driver if the readback register is not present.